### PR TITLE
Only show the pause action if the job is pausable

### DIFF
--- a/app/datatables/rocket_job_mission_control/jobs_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/jobs_datatable.rb
@@ -159,7 +159,7 @@ module RocketJobMissionControl
       if job.scheduled? && view.can?(:run_now, job)
         buttons += "#{ job_action_link('Run', run_now_job_path(job), :patch) }"
       end
-      if events.include?(:pause) && view.can?(:pause, job)
+      if events.include?(:pause) && && job.pauseable? && view.can?(:pause, job)
         buttons += "#{ job_action_link('Pause', pause_job_path(job), :patch) }"
       end
       if events.include?(:resume) && view.can?(:resume, job)

--- a/app/datatables/rocket_job_mission_control/jobs_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/jobs_datatable.rb
@@ -159,7 +159,7 @@ module RocketJobMissionControl
       if job.scheduled? && view.can?(:run_now, job)
         buttons += "#{ job_action_link('Run', run_now_job_path(job), :patch) }"
       end
-      if events.include?(:pause) && && job.pauseable? && view.can?(:pause, job)
+      if events.include?(:pause) && job.pausable? && view.can?(:pause, job)
         buttons += "#{ job_action_link('Pause', pause_job_path(job), :patch) }"
       end
       if events.include?(:resume) && view.can?(:resume, job)

--- a/app/datatables/rocket_job_mission_control/servers_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/servers_datatable.rb
@@ -48,7 +48,7 @@ module RocketJobMissionControl
         actions += "#{ link_to "resume", resume_server_path(server), method: :patch, class: 'btn btn-default', data: {confirm: "Resume this server?"}  }"
       end
 
-      if events.include?(:pause) && view.can?(:pause, server)
+      if events.include?(:pause) && && job.pauseable? && view.can?(:pause, server)
         actions += "#{ link_to "pause", pause_server_path(server), method: :patch, class: 'btn btn-default', data: {confirm: "Pause this server?"} }"
       end
 

--- a/app/datatables/rocket_job_mission_control/servers_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/servers_datatable.rb
@@ -48,7 +48,7 @@ module RocketJobMissionControl
         actions += "#{ link_to "resume", resume_server_path(server), method: :patch, class: 'btn btn-default', data: {confirm: "Resume this server?"}  }"
       end
 
-      if events.include?(:pause) && && job.pauseable? && view.can?(:pause, server)
+      if events.include?(:pause) && view.can?(:pause, server)
         actions += "#{ link_to "pause", pause_server_path(server), method: :patch, class: 'btn btn-default', data: {confirm: "Pause this server?"} }"
       end
 

--- a/app/views/rocket_job_mission_control/jobs/show.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/show.html.erb
@@ -31,7 +31,7 @@
         <div class='btn-group'>
           <% valid_events = @job.aasm.events.collect { |e| e.name } %>
 
-          <% if valid_events.include?(:pause) && can?(:pause, @job)%>
+          <% if valid_events.include?(:pause) && @job.pausable? && can?(:pause, @job)%>
             <%= job_action_link('Pause', rocket_job_mission_control.pause_job_path(@job), :patch) %>
           <% end %>
 


### PR DESCRIPTION
Hide the Pause button in the html and in the JSON view of a job if the job.pausable? is false.