### PR TITLE
Refresh README, add CLAUDE.md, drop dead enterprise gem references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`rocketjob_mission_control` is a **mountable Rails Engine** (namespace `RocketJobMissionControl`) that provides the web UI for managing [Rocket Job](http://rocketjob.io). It is packaged as a gem and mounted into a host Rails app via `mount RocketJobMissionControl::Engine => 'rocketjob'`. Data is persisted in MongoDB through Mongoid; the engine reads and mutates `RocketJob::Job`, `RocketJob::Server`, `RocketJob::Worker`, and `RocketJob::DirmonEntry` documents. It defines no database tables of its own.
+
+## Sister projects (local checkouts)
+
+RJMC is one of a family of gems by the same author, all checked out one directory up (`../`). When a change touches one of these dependencies, read its source directly rather than the installed gem:
+
+- `../rocketjob` — the batch job engine RJMC manages (`RocketJob::Job`, `Server`, `Worker`, `DirmonEntry`).
+- `../semantic_logger`, `../rails_semantic_logger` — logging (`JobsController#error_occurred` special-cases `SemanticLogger::Logger`).
+- `../iostreams` — streaming file I/O used by Rocket Job batch jobs.
+- `../symmetric-encryption` — encryption used for encrypted slices/fields.
+
+Rocket Job Pro and Enterprise functionality has been rolled into `rocketjob` itself; there are no separate `rocketjob_pro` / `rocketjob_enterprise` gems. To develop against a local copy of any dependency, point `rjmc/Gemfile` at `path: "../<gem>"`.
+
+## Commands
+
+Testing uses [Appraisal](https://github.com/thoughtbot/appraisal) to run against multiple Rails/Mongoid combinations (see `Appraisals`: rails_7.2, rails_8.0, rails_8.1). Gems install into the global gem list.
+
+```bash
+bundle install
+appraisal install                     # generate/install gemfiles/*.gemfile
+
+bundle exec rake                      # run tests against ALL appraisals (default task)
+appraisal rails_8.1 rake              # run tests for one Rails version
+
+# single test file / single test case (must run under an appraisal)
+appraisal rails_8.1 ruby -I'test' test/controllers/rocket_job_mission_control/jobs_controller_test.rb
+appraisal rails_8.1 ruby -I'test' test/controllers/rocket_job_mission_control/jobs_controller_test.rb -n "/PATCH #update/"
+
+bundle exec rubocop                   # lint
+```
+
+Note: `bundle exec rake` with no `APPRAISAL_INITIALIZED`/`TRAVIS` env var runs `app:appraisal`, iterating every appraisal. Set `APPRAISAL_INITIALIZED=1` (or run inside `appraisal <name>`) to run the plain `test` task once.
+
+### Dummy app (`rjmc/`)
+
+`rjmc/` is a full dummy Rails app used both as the test harness (`test/test_helper.rb` boots `rjmc/config/environment`) and for running RJMC standalone during development.
+
+```bash
+cd rjmc
+bundle
+bin/rake db:seed        # seed jobs in various states (run repeatedly for more data)
+bin/rails s             # start the web UI
+bin/rails c             # console
+bin/rocketjob           # start a Rocket Job server with 10 workers (processes queued jobs)
+```
+
+To develop against a local checkout of Rocket Job, edit `rjmc/Gemfile` to point `rocketjob` at `path:` instead of `github:`. Seed jobs `AllTypesJob`, `CSVJob`, `KaboomBatchJob` live in the dummy app for DirmonEntry / batch / error-path testing.
+
+## Architecture
+
+### Request flow: DataTables + AJAX
+
+The four resources (jobs, servers, active_workers, dirmon_entries) all render server-side [DataTables](https://datatables.net). Each state view (running/paused/failed/etc.) renders an HTML shell, then the browser issues a JSON request back to the same action (`format: "json"`). The JSON branch is served by a **Datatable** object in `app/datatables/`:
+
+- `AbstractDatatable` (`as_json`) produces the `{draw, recordsTotal, recordsFiltered, data}` payload DataTables expects, and translates DataTables request params (search value, column ordering, `start`/`length` pagination) into a `Query`.
+- Concrete datatables (`jobs_datatable.rb`, etc.) define the column sets (e.g. `JobsDatatable::RUNNING_COLUMNS`, `RUNNING_FIELDS`) and a `map(record)` that turns one Mongoid document into a table row.
+- `Query` (`app/models/`) wraps a Mongoid scope and applies text search (case-insensitive regex over `search_columns`, `$or` across multiple), sorting, and skip/limit pagination. `count` is post-filter, `unfiltered_count` is pre-filter.
+
+When adding a column to a table, update both the `*_COLUMNS` (display) and `*_FIELDS` (the Mongoid `.only(...)` projection) constants, plus `map`.
+
+### Authorization
+
+Uses [access-granted](https://github.com/chaps-io/access-granted). Three pieces:
+
+- `AccessPolicy` (`app/models/`) defines role → permission rules over the `RocketJob::*` classes. Roles: `admin, editor, operator, manager, dirmon, user, view`.
+- `Authorization` (`app/models/`) is the "current user" object. Roles are **hierarchical**: constructing it with a role also grants all lower-privilege roles (`inherit_less_privilege_roles`, ordering defined by `ROLES`). The `user` role is scoped so a user may only act on jobs whose `login` matches.
+- `ApplicationController#current_policy` builds the policy from `Config.authorization_callback`. The host app sets this callback (via `config.rocket_job_mission_control.authorization_callback`) returning `{roles:, login:}`. **When no callback is configured, the default is full admin (`{roles: [:admin]}`)** — auth is opt-in by the host.
+
+Controllers call `authorize! :action, Resource` (provided by access-granted through the policy). `AccessGranted::AccessDenied` is rescued and surfaced as a flash message.
+
+### Parameter sanitizing for dynamic job types
+
+Rocket Job jobs have user-defined fields, so strong-params lists are computed at runtime, not hardcoded:
+
+- `JobsController#job_fields` / `job_params` build permitted params from `job_class.user_editable_fields` and each field's Mongoid type (Array fields permit arrays).
+- `JobSanitizer` / `DirmonSanitizer` (`app/models/`) coerce submitted values by field type: normalize CRLF in Strings, `JSON.parse` Hash fields (adding a model error on parse failure), strip blanks from multi-select Arrays, and null-out blanks. They also fold `input_categories_attributes` / `output_categories_attributes` (batch job I/O category nested forms) into `input_categories` / `output_categories`.
+
+### Routing
+
+`config/routes.rb` roots at `jobs#running`. Each resource exposes one collection action per lifecycle state (jobs: running/scheduled/completed/queued/paused/failed/aborted) plus member actions for state transitions (`abort`, `fail`, `pause`, `resume`, `retry`, `run_now` for jobs; `stop`/`pause`/`resume` for servers; `enable`/`disable`/`copy`/`replicate` for dirmon entries). The `running` jobs action deliberately filters out just-started jobs (`started_at <= now - 0.1`) to hide throttled jobs.
+
+### Engine wiring
+
+`lib/rocket_job_mission_control/engine.rb` `isolate_namespace`s the engine, requires `rocketjob`, and exposes `config.rocket_job_mission_control` → `RocketJobMissionControl::Config` (`mattr_accessor :authorization_callback`). Assets are Sprockets-based.
+
+## Conventions
+
+- Ruby >= 3.2 required (`.rubocop.yml` still targets 2.4 for style only). RuboCop enforces trailing dot position, `lf` line endings, and table-aligned hashes — match the heavy column alignment already used throughout the codebase.
+- Tests are Minitest via `minispec-rails`; controller tests include the engine's route helpers and set `@routes = RocketJobMissionControl::Engine.routes`.
+- Per the global writing-style rule, avoid em dashes in prose and comments.

--- a/README.md
+++ b/README.md
@@ -1,52 +1,36 @@
 # Rocket Job Mission Control
-[![Gem Version](https://img.shields.io/gem/v/rocketjob_mission_control.svg)](https://rubygems.org/gems/rocketjob_mission_control) [![Downloads](https://img.shields.io/gem/dt/rocketjob_mission_control.svg)](https://rubygems.org/gems/rocketjob_mission_control) [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](http://opensource.org/licenses/Apache-2.0) ![](https://img.shields.io/badge/status-Production%20Ready-blue.svg) [![Gitter chat](https://img.shields.io/badge/IRC%20(gitter)-Support-brightgreen.svg)](https://gitter.im/rocketjob/support)
+[![Gem Version](https://img.shields.io/gem/v/rocketjob_mission_control.svg)](https://rubygems.org/gems/rocketjob_mission_control) [![Build Status](https://github.com/reidmorrison/rocketjob_mission_control/workflows/build/badge.svg)](https://github.com/reidmorrison/rocketjob_mission_control/actions?query=workflow%3Abuild) [![Downloads](https://img.shields.io/gem/dt/rocketjob_mission_control.svg)](https://rubygems.org/gems/rocketjob_mission_control) [![License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](http://opensource.org/licenses/Apache-2.0) ![](https://img.shields.io/badge/status-Production%20Ready-blue.svg)
 
-Web based management interface for [Rocket Job][0].
+Rocket Job Mission Control is the web based user interface for [Rocket Job](http://rocketjob.io),
+Ruby's missing batch system.
 
 ![Screen shot](http://rocketjob.io/images/rjmc_running.png)
 
-## Status
+It is a mountable [Rails Engine](https://guides.rubyonrails.org/engines.html) that plugs directly
+into an existing Rails application, giving operators a single place to:
 
-Production Ready
+1. **Manage jobs.** Watch queued, scheduled, running, paused, completed, failed, and aborted jobs in
+   real time, then pause, resume, retry, abort, run, or destroy them, and inspect the exceptions and
+   data of any job.
+2. **Manage servers and workers.** See which servers and workers are active, what each worker is
+   currently processing, and stop, pause, or resume servers.
+3. **Manage directory monitoring.** Create, edit, enable, disable, copy, and replicate
+   [Directory Monitor](http://rocketjob.io/dirmon.html) entries that turn arriving files into jobs.
 
-Already in use in production processing large files with millions
-of records, as well as large jobs to walk through large databases.
-
-## Features
-
-Job Management
-
-* View all queued, running, failed, and running jobs.
-* View all completed jobs where `destroy_on_complete` is `false`.
-* Pause any running jobs.
-* Resume paused jobs.
-* Retry failed jobs.
-* Abort, or fail queued or running jobs.
-* Destroy a completed or aborted job.
-
-Server Management
-
-* View running servers.
-* Stop servers.
-
-Running Jobs
-
-* View the jobs that workers are currently working on.
-
-Directory Monitor Management
-
-* Create, update, enable, disable directory monitoring entries.
+Already in use in production processing large files with millions of records, as well as large jobs
+that walk through entire databases.
 
 ## Documentation
 
-* [Guide](http://rocketjob.io/mission_control)
+* [Rocket Job Mission Control Guide](http://rocketjob.io/mission_control)
+* [Rocket Job Guide](http://rocketjob.io)
 
-## Rails Installation
+## Install
 
-This gem is a Rails Engine and can be installed directly into existing Rails 4
-or 5 applications.
+Rocket Job Mission Control is a Rails Engine. It can be mounted into any existing Rails 7.2, 8.0, or
+8.1 application backed by MongoDB (via Mongoid).
 
-Add to Gemfile:
+Add to the host application's `Gemfile`:
 
 ```ruby
 gem 'rocketjob_mission_control'
@@ -54,19 +38,36 @@ gem 'rocketjob_mission_control'
 
 Install:
 
-```ruby
-bundle
+```sh
+bundle install
 ```
 
-Add the following route to `config/routes.rb`:
+Mount the engine by adding the following route to `config/routes.rb`:
 
 ```ruby
-mount RocketJobMissionControl::Engine => 'rocketjob'
+mount RocketJobMissionControl::Engine => '/rocketjob'
 ```
+
+Mission Control is now available at `/rocketjob`.
+
+## Authorization
+
+By default Mission Control grants full access to every action. To restrict access, register an
+authorization callback that returns the roles (and optional `login`) for the current request:
+
+```ruby
+Rails.application.config.rocket_job_mission_control.authorization_callback = -> do
+  { roles: current_user.rocket_job_roles, login: current_user.login }
+end
+```
+
+Available roles are `admin`, `editor`, `operator`, `manager`, `dirmon`, `user`, and `view`. Roles
+are hierarchical, so granting a higher-privilege role also grants the lower ones.
 
 ## Development and Testing
 
-* [Development and Testing](TESTING.md) documentation.
+See [TESTING.md](TESTING.md) for how to set up the project, run the test suite across supported Rails
+versions, and run Mission Control standalone against the bundled dummy application.
 
 ## Versioning
 
@@ -74,13 +75,9 @@ This project uses [Semantic Versioning](http://semver.org/).
 
 ## Authors
 
-* [Michael Cloutier][1]
-* [Chris Lamb][2]
-* [Jonathan Whittington][4]
-* [Reid Morrison][3] :: @reidmorrison
+* [Michael Cloutier](https://github.com/mjcloutier)
+* [Chris Lamb](https://github.com/lambcr)
+* [Jonathan Whittington](https://github.com/jtwhittington)
+* [Reid Morrison](https://github.com/reidmorrison)
 
-[0]: http://rocketjob.io
-[1]: https://github.com/mjcloutier
-[2]: https://github.com/lambcr
-[3]: https://github.com/reidmorrison
-[4]: https://github.com/jtwhittington
+[Contributors](https://github.com/reidmorrison/rocketjob_mission_control/graphs/contributors)

--- a/TESTING.md
+++ b/TESTING.md
@@ -40,13 +40,12 @@ Run bundler to install the gems:
 
     bundle
     
-If you have Rocket Job and/or Rocket Job Pro checked out locally, you can point to those installations
-instead of the current gems by editing Gemfile and uncommenting the following 2 lines as applicable:
+If you have Rocket Job checked out locally, you can point to that installation
+instead of the current gem by editing Gemfile and uncommenting the following line:
 
 ~~~ruby
-# For testing with local copies of the gems:
+# For testing with a local copy of the gem:
 gem 'rocketjob', path: '../../rocketjob'
-gem 'rocketjob_pro', path: '../../rocketjob_pro'
 ~~~
 
 Optionally pre-load the database with jobs in the various states to assist with development:
@@ -79,8 +78,8 @@ For testing purposes the following Jobs are supplied with the rjmc dummy Rails a
 * AllTypesJob
     * Ideal for DirmonEntry Testing.
 * CSVJob
-    * For testing against RocketJob Pro.
+    * For testing batch jobs.
 * KaboomBatchJob
-    * For testing against RocketJob Pro.
+    * For testing batch jobs.
     * Creates test data with intentional errors and exceptions.
     

--- a/lib/rocket_job_mission_control/engine.rb
+++ b/lib/rocket_job_mission_control/engine.rb
@@ -10,11 +10,6 @@ module RocketJobMissionControl
     require "rocketjob"
     require "access-granted"
 
-    begin
-      require "rocketjob_enterprise"
-    rescue LoadError
-    end
-
     config.rocket_job_mission_control = ::RocketJobMissionControl::Config
 
     config.to_prepare do


### PR DESCRIPTION
## Summary

Documentation refresh plus a small dead-code cleanup. No behavior change to the running app.

- **README.md** rewritten in the style of the [semantic_logger](https://github.com/reidmorrison/semantic_logger) README:
  - Swapped the defunct Gitter badge for a GitHub Actions build-status badge.
  - Corrected the stale "existing Rails 4 or 5 applications" install note to the actually-supported Rails 7.2 / 8.0 / 8.1 (matching the gemspec and `Appraisals`), and noted the MongoDB/Mongoid requirement.
  - Fixed the duplicated "running jobs" bullet and a mis-tagged `bundle` code fence.
  - Added an **Authorization** section documenting the `config.rocket_job_mission_control.authorization_callback` API and the seven roles (previously undocumented; the default is full access).
- **CLAUDE.md** added: engine architecture, the DataTables + `Query` request flow, the access-granted authorization model, runtime job-param sanitizing, sister-project checkouts, and the Appraisal-based test/dev commands.
- **Dead enterprise references removed.** Rocket Job Pro and Enterprise functionality was rolled into `rocketjob` itself, so there is no longer a `rocketjob_enterprise` gem. Removed the soft `require "rocketjob_enterprise"` from the engine and the RocketJob Pro references in `TESTING.md`.

## Test plan

- Docs-only plus removal of a no-op `require` (it was already wrapped in `rescue LoadError`), so no functional change.
- CI (`build` workflow) should remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)