### PR TITLE
Cosmic theme: category panels and slice/exception page titles

### DIFF
--- a/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
+++ b/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
@@ -157,15 +157,31 @@ div.row {
   border-color: var(--cosmic-blue-dark);
 }
 
-/* Detail/show page label:value tables span the full content width, with the
-   label column shrunk to its content so the value column takes the rest. */
+/* Detail/show page label:value tables: full width with a clean, professional
+   look - zebra striping, comfortable padding, and a muted bold label column
+   shrunk to its content so the value column takes the rest. */
 .col-md-12 > table {
   width: 100%;
+  margin-bottom: 1.5em;
+  border: 1px solid #e6e9f0;
+  border-radius: 4px;
 }
-.col-md-12 > table > tbody > tr > td:first-child,
-.col-md-12 > table > tr > td:first-child {
+.col-md-12 > table td {
+  padding: 7px 14px;
+  vertical-align: top;
+}
+.col-md-12 > table tr:nth-child(even) {
+  background-color: #f5f7fb;
+}
+.col-md-12 > table td:first-child {
   width: 1%;
   white-space: nowrap;
+  color: #5a6572;
+}
+.col-md-12 > table td:first-child label {
+  margin-bottom: 0;
+  font-weight: 600;
+  color: inherit;
 }
 
 /* Input/Output Categories sub-panels themed to the brand two-tone:
@@ -535,6 +551,27 @@ h3 { margin-top: 0; }
 .page-title-bar .pagination-buttons,
 .page-title-bar .pagination-buttons .pagination {
   margin: 0;
+}
+
+/* Consistent, themed section sub-headers on the detail/show pages
+   (Details, Dates, Exceptions, Input Categories, ...). */
+.section-header {
+  margin: 1.5em 0 0.75em;
+  padding-bottom: 6px;
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--cosmic-blue);
+  border-bottom: 2px solid #dce3f0;
+}
+.section-header:first-child {
+  margin-top: 0;
+}
+/* Nested sub-header (e.g. each category name under Input/Output Categories). */
+.subsection-header {
+  margin: 1em 0 0.5em;
+  font-size: 15px;
+  font-weight: bold;
+  color: var(--cosmic-blue);
 }
 
 /* Themed collection-action buttons in the DataTables toolbar: individual,

--- a/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
+++ b/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
@@ -168,6 +168,24 @@ div.row {
   white-space: nowrap;
 }
 
+/* Input/Output Categories sub-panels themed to the brand two-tone:
+   Input (panel-primary) = cosmic blue, Output (panel-success) = flame orange. */
+.panel-primary { border-color: var(--cosmic-blue); }
+.panel-primary > .panel-heading {
+  color: #fff;
+  background-color: var(--cosmic-blue);
+  border-color: var(--cosmic-blue);
+}
+.panel-primary > .panel-heading + .panel-collapse > .panel-body { border-top-color: var(--cosmic-blue); }
+
+.panel-success { border-color: #e8760f; }
+.panel-success > .panel-heading {
+  color: #fff;
+  background-color: #e8760f;
+  border-color: #e8760f;
+}
+.panel-success > .panel-heading + .panel-collapse > .panel-body { border-top-color: #e8760f; }
+
 .job-list {
   height: 100%;
   min-height: 768px;
@@ -500,6 +518,23 @@ h3 { margin-top: 0; }
 }
 .page-title-bar .page-title {
   color: #eef2fb;
+}
+/* Links in the title (e.g. the job-class link on the slice/exception pages)
+   stay readable on the dark bar. */
+.page-title-bar .page-title a {
+  color: #fff;
+  text-decoration: underline;
+}
+.page-title-bar .page-title a:hover,
+.page-title-bar .page-title a:focus {
+  color: #fff;
+  text-decoration: none;
+}
+/* Keep pagination controls from inflating the title-bar height so it matches
+   the other list titles. */
+.page-title-bar .pagination-buttons,
+.page-title-bar .pagination-buttons .pagination {
+  margin: 0;
 }
 
 /* Themed collection-action buttons in the DataTables toolbar: individual,

--- a/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_attributes.html.erb
@@ -1,4 +1,4 @@
-<div class='lead'>Attributes:</div>
+<div class='section-header'>Attributes</div>
 <div class='row'>
   <div class='col-md-12'>
     <table>

--- a/app/views/rocket_job_mission_control/jobs/_dates.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_dates.html.erb
@@ -1,4 +1,4 @@
-<div class='lead'>Dates:</div>
+<div class='section-header'>Dates</div>
 <div class='row'>
   <div class='col-md-12'>
     <table>

--- a/app/views/rocket_job_mission_control/jobs/_details.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_details.html.erb
@@ -1,4 +1,4 @@
-<div class='lead'>Details:</div>
+<div class='section-header'>Details</div>
 <div class='row'>
   <div class='col-md-12 job-status'>
     <table>

--- a/app/views/rocket_job_mission_control/jobs/_exception.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_exception.html.erb
@@ -1,4 +1,4 @@
-<div class='lead'>Exception:</div>
+<div class='section-header'>Exception</div>
 <div class='row'>
   <div class='col-md-12'>
     <table>

--- a/app/views/rocket_job_mission_control/jobs/_input_categories.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_input_categories.html.erb
@@ -1,8 +1,8 @@
-<div class='lead'>Input Categories:</div>
+<div class='section-header'>Input Categories</div>
 <% @job.input_categories.each do |category| %>
   <div class='row'>
     <div class='col-md-12'>
-      <div class='lead'><label><%= category.name.to_s.camelcase %>:</label></div>
+      <div class='subsection-header'><%= category.name.to_s.camelcase %></div>
       <div class='row'>
         <div class='col-md-12'>
           <table>

--- a/app/views/rocket_job_mission_control/jobs/_output_categories.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_output_categories.html.erb
@@ -1,8 +1,8 @@
-<div class='lead'>Output Categories:</div>
+<div class='section-header'>Output Categories</div>
 <% @job.output_categories.each do |category| %>
   <div class='row'>
     <div class='col-md-12'>
-      <div class='lead'><label><%= category.name.to_s.camelcase %>:</label></div>
+      <div class='subsection-header'><%= category.name.to_s.camelcase %></div>
       <div class='row'>
         <div class='col-md-12'>
           <table>

--- a/app/views/rocket_job_mission_control/jobs/_retryable.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_retryable.html.erb
@@ -1,4 +1,4 @@
-<div class='lead'>Retryable:</div>
+<div class='section-header'>Retryable</div>
 <div class='row'>
   <div class='col-md-12'>
     <table>

--- a/app/views/rocket_job_mission_control/jobs/_status.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_status.html.erb
@@ -9,7 +9,7 @@
 <% end %>
 <% if @job.respond_to?(:input) && @job.input.failed.count.positive? %>
   <div class='status-message'>
-    <label><%= 'Exceptions' %>:</label>
+    <div class='section-header'>Exceptions</div>
     <%= render partial: 'exceptions', locals: {job: @job} %>
   </div>
 <% elsif @job.exception.present? %>
@@ -17,7 +17,7 @@
 <% end %>
 <% if @job.respond_to?(:statistics) && @job.statistics.present? %>
   <div class='status-message'>
-    <label>Statistics:</label>
+    <div class='section-header'>Statistics</div>
     <td><%= @job.statistics.ai(html: true, plain: true, sort_keys: true) %></td>
   </div>
   <br/>

--- a/app/views/rocket_job_mission_control/jobs/exception.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/exception.html.erb
@@ -1,15 +1,23 @@
 <div class='row'>
   <div class='col-md-8'>
+    <div class="panel panel-default">
+      <div class="panel-heading page-title-bar">
+        <div class='row'>
+          <div class='col-sm-8'>
+            <h2 class='page-title'><%= link_to(@job.class.name, job_path(@job)) %>: <%= @failure_exception.class_name %></h2>
+          </div>
+
+          <div class='col-sm-4'>
+            <div class='pagination-buttons pull-right'>
+              <%= render partial: 'pagination', locals: {error_type: @failure_exception.class_name, pagination: @pagination} %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class='job-status'>
       <div class='failures'>
-        <div class='lead'><%= link_to(@job.class.name, job_path(@job)) %>: <%= @failure_exception.class_name %></div>
-
-        <div class='pagination-buttons pull-right'>
-          <%= render partial: 'pagination', locals: {error_type: @failure_exception.class_name, pagination: @pagination} %>
-        </div>
-
-        <div class='clearfix'></div>
-
         <div class='message'>
           <pre><code class="language-html"><%= @failure_exception.message %></code></pre>
         </div>

--- a/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
@@ -1,15 +1,23 @@
 <div class='edit_input'>
   <div class='col-md-10'>
+    <div class="panel panel-default">
+      <div class="panel-heading page-title-bar">
+        <div class='row'>
+          <div class='col-sm-8'>
+            <h2 class='page-title'><%= link_to(@job.class, job_path(@job)) %>: <%= @failure_exception.class_name %></h2>
+          </div>
+
+          <div class='col-sm-4'>
+            <div class='pagination-buttons pull-right'>
+              <%= render partial: 'view_slice_pagination', locals: {error_type: @failure_exception.class_name, pagination: @view_slice_pagination} %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div class='job-status'>
       <div class='failures'>
-        <div class='lead'><%= link_to(@job.class, job_path(@job)) %>: <%= @failure_exception.class_name %></div>
-
-        <div class='pagination-buttons pull-right'>
-          <%= render partial: 'view_slice_pagination', locals: {error_type: @failure_exception.class_name, pagination: @view_slice_pagination} %>
-        </div>
-
-        <div class='clearfix'></div>
-
         <div class='message'>
           <pre><code class="language-html"><%= @failure_exception.message %></code></pre>
         </div>


### PR DESCRIPTION
Follow-up to #99, extending the cosmic theme to the last few pages.

## Changes

- **Input/Output Categories sub-panels** themed to the brand two-tone — Input (`panel-primary`) = cosmic blue, Output (`panel-success`) = flame orange — replacing the clashing Bootstrap green. These panel classes are used only for input/output categories (job edit form, dirmon new/edit/copy forms), so nothing else is affected.
- **view_slice** and **exception** pages now use the same gunmetal `page-title-bar` heading as the index/show/edit pages, with the pagination controls on the right (mirroring the index title + reload layout).
- Added a light, underlined link color for links inside the title bar (the job-class link on these pages would otherwise be low-contrast cosmic-blue on the dark bar).
- Kept the pagination controls from inflating the title-bar height so it matches the other page titles.

## Testing

- Jobs controller tests: 135/0.
- ERB templates for the changed views compile.
- The view_slice / exception pages are only reachable via a failed batch job's slice viewer, so they aren't covered by controller tests; verify with a seeded failed batch job (e.g. `KaboomBatchJob`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)