### PR TITLE
Expand dummy app seed data to exercise all Mission Control views

### DIFF
--- a/rjmc/app/jobs/data_import_job.rb
+++ b/rjmc/app/jobs/data_import_job.rb
@@ -1,0 +1,21 @@
+# A batch job that reads a CSV file, normalizes each record, and collects the
+# transformed output.
+#
+# Demonstrates the batch input/output categories, slices, and output views.
+class DataImportJob < RocketJob::Job
+  include RocketJob::Batch
+
+  self.description         = "Import customer records and normalize them"
+  self.destroy_on_complete = false
+
+  input_category  format: :csv
+  output_category format: :csv
+
+  field :region, type: String, default: "us-east", user_editable: true
+
+  def perform(record)
+    record["name"]  = record["name"].to_s.strip.upcase
+    record["state"] = record["state"].to_s.strip.upcase
+    record
+  end
+end

--- a/rjmc/app/jobs/email_blast_job.rb
+++ b/rjmc/app/jobs/email_blast_job.rb
@@ -1,0 +1,18 @@
+# A simple job with a variety of user editable fields.
+#
+# Demonstrates the edit/new forms with strings, arrays, and multi-select fields.
+class EmailBlastJob < RocketJob::Job
+  self.description = "Send a marketing email blast to a customer segment"
+  self.priority    = 40
+
+  field :subject,    type: String, user_editable: true
+  field :body,       type: String, user_editable: true
+  field :segment,    type: String, user_editable: true
+  field :recipients, type: Array,  default: [], user_editable: true
+
+  validates :segment, inclusion: %w[new active lapsed vip]
+
+  def perform
+    # Pretend to send emails.
+  end
+end

--- a/rjmc/app/jobs/report_job.rb
+++ b/rjmc/app/jobs/report_job.rb
@@ -1,0 +1,21 @@
+# A recurring, cron scheduled job.
+#
+# Demonstrates the Scheduled jobs view and the cron schedule detail.
+class ReportJob < RocketJob::Job
+  include RocketJob::Plugins::Cron
+
+  # Every weekday at 06:00 Eastern.
+  self.cron_schedule = "0 6 * * 1-5 America/New_York"
+  self.description   = "Generate and email the daily sales report"
+  self.priority      = 30
+
+  field :report_type, type: String, default: "daily", user_editable: true
+  field :recipients,  type: Array,  default: [], user_editable: true
+  field :include_charts, type: Mongoid::Boolean, default: true, user_editable: true
+
+  validates :report_type, inclusion: %w[daily weekly monthly]
+
+  def perform
+    # Pretend to build a report.
+  end
+end

--- a/rjmc/db/seeds.rb
+++ b/rjmc/db/seeds.rb
@@ -1,59 +1,279 @@
-# Create sample jobs in the various states.
-# Loaded with the rake db:seed
+# Create sample data so that every RocketJob Mission Control view can be
+# exercised without a running Rocket Job cluster.
 #
-# Note: Assumes Rocket Job servers/workers are not active.
+# Loaded with `bin/rake db:seed`. Safe to run repeatedly, each run adds more
+# data. Assumes Rocket Job servers/workers are not active.
 #
-# Scheduled Jobs
-RocketJob::Jobs::SimpleJob.create!(run_at: 1.year.from_now)
+# Covers:
+#   - Jobs in every state: scheduled, queued, running, paused, failed, aborted, completed
+#   - Regular jobs, batch jobs, cron scheduled jobs, and jobs with user editable fields
+#   - Batch jobs with slices, collected output, and failed slice exceptions
+#   - Servers in various states (populates the Servers view)
+#   - Active workers (populates the Active Workers view)
+#   - Dirmon entries in every state: pending, enabled, disabled, failed
 
-# Queued Jobs
-RocketJob::Jobs::SimpleJob.create!
-AllTypesJob.create!(string: "Hello World", string_values: "three")
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
-# Paused Jobs
-RocketJob::Jobs::SimpleJob.new.pause!
-
-# Failed Jobs
-RocketJob::Jobs::SimpleJob.new.fail!("Oh no", "TestWorker")
-
-# Aborted Jobs
-RocketJob::Jobs::SimpleJob.new.abort!
-
-# Running Jobs with varying priority
-
-RocketJob::Jobs::SimpleJob.new(priority: 50).start!
-RocketJob::Jobs::SimpleJob.new(priority: 60).start!
-RocketJob::Jobs::SimpleJob.new(priority: 10).start!
-RocketJob::Jobs::SimpleJob.new(priority: 90).start!
-
-# KaboomBatchJob with exceptions.
-count = 100
-job   = KaboomBatchJob.new
-job.input_category.serializer = :none
-job.input_category.slice_size = 10
-job.upload do |stream|
-  count.times { |i| stream << "Line number #{i + 1}" }
+# Force a job into the running state and pin it to a worker so that it shows up
+# in both the running jobs view and the active workers view.
+def pretend_running!(job, worker_name)
+  job.start
+  job.worker_name = worker_name
+  job.started_at  = rand(1..90).minutes.ago
+  job.save!
+  job
 end
 
-# Manually run job to get some failures without needing workers.
-while job.input.queued.count.positive?
-  begin
-    job.perform_now
-  rescue StandardError
-    # perform_now re-raises exceptions.
+# Fail a job with a realistic looking exception, including a backtrace.
+def fail_with_exception!(job, exception_class, message, worker_name)
+  exception = begin
+    raise exception_class, message
+  rescue exception_class => e
+    e
+  end
+  job.start
+  job.worker_name = worker_name
+  job.fail!(worker_name, exception)
+  job
+end
+
+WORKERS = [
+  "batch-server-01:34521:worker-001",
+  "batch-server-01:34521:worker-002",
+  "batch-server-02:51002:worker-001",
+  "web-server-03:22981:worker-001"
+].freeze
+
+# ---------------------------------------------------------------------------
+# Scheduled jobs (run_at in the future, and cron scheduled jobs)
+# ---------------------------------------------------------------------------
+
+RocketJob::Jobs::SimpleJob.create!(run_at: 1.hour.from_now, description: "Warm the cache", priority: 55)
+RocketJob::Jobs::SimpleJob.create!(run_at: 1.day.from_now, description: "Nightly reconciliation", priority: 20)
+RocketJob::Jobs::SimpleJob.create!(run_at: 1.year.from_now, description: "Annual archive", priority: 70)
+
+# Cron scheduled jobs.
+ReportJob.create!(report_type: "daily", recipients: %w[ops@example.com finance@example.com])
+ReportJob.create!(report_type: "weekly", cron_schedule: "0 7 * * 1 America/New_York", priority: 25)
+RocketJob::Jobs::HousekeepingJob.create!
+
+# ---------------------------------------------------------------------------
+# Queued jobs (a variety of types and priorities)
+# ---------------------------------------------------------------------------
+
+RocketJob::Jobs::SimpleJob.create!
+AllTypesJob.create!(
+  string:        "Hello World",
+  string_values: "three",
+  integer:       42,
+  float:         3.14,
+  boolean:       true,
+  symbol:        :ready,
+  array:         %w[alpha beta gamma],
+  hash_field:    {"nested" => {"key" => "value"}, "count" => 3}
+)
+EmailBlastJob.create!(
+  subject:    "Summer Sale",
+  body:       "Everything must go!",
+  segment:    "active",
+  recipients: %w[alice@example.com bob@example.com],
+  priority:   35
+)
+EmailBlastJob.create!(subject: "Win-back campaign", segment: "lapsed", priority: 65)
+RocketJob::Jobs::OnDemandJob.create!(
+  description: "One off data cleanup",
+  code:        "RocketJob.logger.info 'Running on demand cleanup'"
+)
+
+# ---------------------------------------------------------------------------
+# Paused jobs
+# ---------------------------------------------------------------------------
+
+RocketJob::Jobs::SimpleJob.new(description: "Paused for maintenance").pause!
+EmailBlastJob.new(subject: "Paused blast", segment: "vip").pause!
+
+# ---------------------------------------------------------------------------
+# Failed jobs (various exception types with backtraces)
+# ---------------------------------------------------------------------------
+
+fail_with_exception!(RocketJob::Jobs::SimpleJob.new(description: "Downstream API call"),
+                     RuntimeError, "Connection refused - connect(2) for api.example.com:443", WORKERS[0])
+fail_with_exception!(AllTypesJob.new(string: "boom", string_values: "one"),
+                     ArgumentError, "Invalid argument: expected Integer, got String", WORKERS[1])
+fail_with_exception!(EmailBlastJob.new(subject: "Failed blast", segment: "new"),
+                     StandardError, "SMTP server did not respond", WORKERS[3])
+
+# Simple fail without a full exception object.
+RocketJob::Jobs::SimpleJob.new(description: "Legacy failure").fail!("Oh no", "TestWorker")
+
+# ---------------------------------------------------------------------------
+# Aborted jobs
+# ---------------------------------------------------------------------------
+
+RocketJob::Jobs::SimpleJob.new(description: "Cancelled by operator").abort!
+EmailBlastJob.new(subject: "Aborted blast", segment: "active").abort!
+
+# ---------------------------------------------------------------------------
+# Running jobs (varying priority, pinned to workers for the Active Workers view)
+# ---------------------------------------------------------------------------
+
+pretend_running!(RocketJob::Jobs::SimpleJob.new(priority: 10, description: "High priority sync"), WORKERS[0])
+pretend_running!(RocketJob::Jobs::SimpleJob.new(priority: 50, description: "Normal batch"), WORKERS[1])
+pretend_running!(RocketJob::Jobs::SimpleJob.new(priority: 90, description: "Low priority backfill"), WORKERS[2])
+pretend_running!(EmailBlastJob.new(priority: 40, subject: "In flight blast", segment: "vip"), WORKERS[3])
+
+# ---------------------------------------------------------------------------
+# Batch jobs
+# ---------------------------------------------------------------------------
+
+# Completed batch job with collected output (destroy_on_complete = false).
+import = DataImportJob.new(region: "us-west")
+import.input_category.slice_size = 3
+import.output_category.columns   = %w[name age state]
+import.upload do |stream|
+  stream << "name,age,state"
+  %w[alice bob carol dave erin frank grace].each_with_index do |name, i|
+    stream << "#{name},#{20 + i},ca"
   end
 end
-job.save!
+import.perform_now
+import.save!
 
-# Running Jobs
-job = CSVJob.new
-job.input_category.slice_size = 1
-job.upload do |stream|
-  # Write header row.
+# Completed CSV batch job.
+csv = CSVJob.new
+csv.input_category.slice_size = 1
+csv.upload do |stream|
   stream << "name,age,state"
-
-  # Write 10 lines.
   10.times { |i| stream << "jack,#{i + 20},FL" }
 end
-job.perform_now
-job.save!
+csv.perform_now
+csv.save!
+
+# Batch job left with failed slices and exceptions (KaboomBatchJob raises on
+# every record). Manually processed so no workers are required.
+kaboom = KaboomBatchJob.new
+kaboom.input_category.serializer = :none
+kaboom.input_category.slice_size = 10
+kaboom.upload do |stream|
+  100.times { |i| stream << "Line number #{i + 1}" }
+end
+while kaboom.input.queued.count.positive?
+  begin
+    kaboom.perform_now
+  rescue StandardError
+    # perform_now re-raises exceptions; ignore so remaining slices process.
+  end
+end
+kaboom.save!
+
+# Queued batch job (uploaded but not started) so the batch input slices view has
+# pending work to show.
+pending_batch = CSVJob.new(description: "Awaiting workers")
+pending_batch.input_category.slice_size = 5
+pending_batch.upload do |stream|
+  stream << "name,age,state"
+  25.times { |i| stream << "pat,#{30 + i},NY" }
+end
+pending_batch.save!
+
+# ---------------------------------------------------------------------------
+# Servers (populates the Servers view)
+# ---------------------------------------------------------------------------
+
+def build_heartbeat(workers)
+  RocketJob::Heartbeat.new(updated_at: Time.now, workers: workers)
+end
+
+RocketJob::Server.create!(
+  name:        "batch-server-01:34521",
+  max_workers: 10,
+  started_at:  3.hours.ago,
+  state:       :running,
+  heartbeat:   build_heartbeat(8)
+)
+RocketJob::Server.create!(
+  name:        "batch-server-02:51002",
+  max_workers: 10,
+  started_at:  90.minutes.ago,
+  state:       :running,
+  heartbeat:   build_heartbeat(4)
+)
+RocketJob::Server.create!(
+  name:        "web-server-03:22981",
+  max_workers: 5,
+  started_at:  20.minutes.ago,
+  state:       :paused,
+  heartbeat:   build_heartbeat(0)
+)
+RocketJob::Server.create!(
+  name:        "batch-server-04:19222",
+  max_workers: 10,
+  started_at:  5.minutes.ago,
+  state:       :starting,
+  heartbeat:   build_heartbeat(0)
+)
+RocketJob::Server.create!(
+  name:        "batch-server-05:44100",
+  max_workers: 10,
+  started_at:  4.hours.ago,
+  state:       :stopping,
+  heartbeat:   build_heartbeat(2)
+)
+# A zombie server whose heartbeat has gone stale.
+RocketJob::Server.create!(
+  name:        "batch-server-06:60333",
+  max_workers: 10,
+  started_at:  1.day.ago,
+  state:       :running,
+  heartbeat:   RocketJob::Heartbeat.new(updated_at: 1.hour.ago, workers: 10)
+)
+
+# ---------------------------------------------------------------------------
+# Dirmon entries (populates the Dirmon Entries view, one per state)
+# ---------------------------------------------------------------------------
+
+# Pending (default state on create).
+RocketJob::DirmonEntry.create!(
+  name:              "Import customers",
+  pattern:           "input_files/customers/*.csv",
+  job_class_name:    "DataImportJob",
+  archive_directory: "archive/customers",
+  properties:        {"description" => "Imported via Dirmon", "priority" => 45}
+)
+
+# Enabled.
+enabled = RocketJob::DirmonEntry.new(
+  name:              "Process orders",
+  pattern:           "input_files/orders/*.{csv,txt}",
+  job_class_name:    "CSVJob",
+  archive_directory: "archive/orders",
+  properties:        {"priority" => 30}
+)
+enabled.enable!
+
+# Disabled.
+disabled = RocketJob::DirmonEntry.new(
+  name:              "Legacy feed (paused)",
+  pattern:           "input_files/legacy/**/*",
+  job_class_name:    "CSVJob",
+  archive_directory: "archive/legacy"
+)
+disabled.enable!
+disabled.disable!
+
+# Failed, with an exception explaining why.
+failed = RocketJob::DirmonEntry.new(
+  name:              "Restricted uploads",
+  pattern:           "/etc/*.conf",
+  job_class_name:    "CSVJob",
+  archive_directory: "archive/restricted"
+)
+failed.enable!
+failed.fail!("dirmon-worker:1234", "Security violation: pattern is not in the whitelist_paths")
+
+puts "Seed data created."
+puts "  Jobs:           #{RocketJob::Job.count}"
+puts "  Servers:        #{RocketJob::Server.count}"
+puts "  Dirmon entries: #{RocketJob::DirmonEntry.count}"


### PR DESCRIPTION
## What

Significantly expands `rjmc/db/seeds.rb` (and adds a few dummy job classes) so that **every** RocketJob Mission Control view can be exercised without a running Rocket Job cluster.

## Seed coverage (verified after a clean run)

- **Jobs in every state** — queued: 12 (includes scheduled + cron jobs with a future `run_at`), running: 5, failed: 4, aborted: 2, paused: 2, completed: 2.
- **Failed jobs** with realistic exceptions and backtraces (RuntimeError, ArgumentError, StandardError), plus a bare-message failure.
- **Batch jobs** — a completed `DataImportJob` with collected output, a completed `CSVJob`, a `KaboomBatchJob` left with failed slice exceptions, and a queued `CSVJob` with pending slices.
- **Servers** (6) across running / paused / starting / stopping, plus a stale-heartbeat zombie.
- **Active workers** (4) — running jobs pinned to worker names matching the seeded servers.
- **Dirmon entries** — one each in pending / enabled / disabled / failed (the failed one carries a whitelist-violation exception).

The seed is safe to run repeatedly (each run adds more data) and prints a summary of counts.

## New dummy job classes

- `ReportJob` — cron-scheduled job with user-editable fields (scheduled view + cron detail).
- `DataImportJob` — batch job with CSV input and collected CSV output (batch slices + output view).
- `EmailBlastJob` — simple job with string / array / multi-select fields (new/edit forms).

## Testing

- `bin/rake db:seed` runs cleanly end to end.
- `bundle exec rubocop` reports no offenses on the changed files.
- Verified job/server/dirmon state distribution and active-worker counts via `bin/rails runner`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)