### PR TITLE
Add batch job slice progress bar (issue #50)

### DIFF
--- a/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
+++ b/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
@@ -285,6 +285,49 @@ h3 { margin-top: 0; }
 .job-status .job-state .failed { background-color: red; }
 .job-status .job-state .aborted { background-color: darkorange; }
 
+/* Batch job slice progress bar: a single horizontal stacked bar whose
+   segments reuse the state colors above (Queued, Active, Failed, Completed). */
+.slice-bar {
+  display: flex;
+  width: 100%;
+  max-width: 600px;
+  height: 22px;
+  border-radius: 3px;
+  overflow: hidden;
+  background-color: #eee;
+}
+
+.slice-bar-segment { height: 100%; }
+.slice-bar-segment.queued    { background-color: #a29f00; }
+.slice-bar-segment.running   { background-color: #337ab7; }
+.slice-bar-segment.failed    { background-color: red; }
+.slice-bar-segment.completed { background-color: green; }
+
+.slice-bar-legend {
+  margin-top: 6px;
+  font-size: 12px;
+}
+
+.slice-bar-legend-item {
+  display: inline-block;
+  margin-right: 12px;
+  white-space: nowrap;
+}
+
+.slice-bar-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 4px;
+  border-radius: 2px;
+  vertical-align: middle;
+}
+
+.slice-bar-swatch.queued    { background-color: #a29f00; }
+.slice-bar-swatch.running   { background-color: #337ab7; }
+.slice-bar-swatch.failed    { background-color: red; }
+.slice-bar-swatch.completed { background-color: green; }
+
 .job-status .priority {
   display: inline-block;
   vertical-align: middle;

--- a/app/helpers/rocket_job_mission_control/jobs_helper.rb
+++ b/app/helpers/rocket_job_mission_control/jobs_helper.rb
@@ -66,6 +66,46 @@ module RocketJobMissionControl
       ((job.record_count.to_f / secs) * 60 * 60).round if job.record_count&.positive? && (secs > 0.0)
     end
 
+    # Ordered slice buckets for the batch job progress bar, each as
+    # [label, css_state_class, count, percent_of_bar]. Left to right:
+    # Queued, Active, Failed, Completed.
+    #
+    # Completed input slices are deleted as they finish, so the completed count
+    # is derived from the total expected slices (see #job_total_slices) minus
+    # those still queued, running, or failed. The percentages are normalized so
+    # the four segments always fill the bar.
+    #
+    # The record count is set before a batch job starts running, so until it is
+    # known the total is nil and every percentage is zero, leaving the bar empty.
+    def job_slice_stats(job)
+      queued    = job.input.queued.count
+      active    = job.input.running.count
+      failed    = job.input.failed.count
+      total     = job_total_slices(job)
+      completed = total ? [total - queued - active - failed, 0].max : 0
+
+      buckets = [
+        ["Queued",    "queued",    queued],
+        ["Active",    "running",   active],
+        ["Failed",    "failed",    failed],
+        ["Completed", "completed", completed]
+      ]
+      sum = buckets.sum(&:last)
+      buckets.map do |label, css_class, count|
+        percent = total && sum.positive? ? ((count * 100.0) / sum).round(2) : 0
+        [label, css_class, count, percent]
+      end
+    end
+
+    # Total number of input slices originally created for a batch job, or nil
+    # when the record count is not yet known (for example while records are
+    # still being uploaded).
+    def job_total_slices(job)
+      return nil unless job.record_count&.positive?
+
+      (job.record_count.to_f / job.input_category.slice_size).ceil
+    end
+
     def job_custom_fields(job)
       attrs = job.attributes.dup
       DISPLAYED_FIELDS.each { |key| attrs.delete(key) }

--- a/app/views/rocket_job_mission_control/jobs/_details.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_details.html.erb
@@ -67,17 +67,24 @@
               <td><%= job_estimated_time_left(@job) %></td>
             </tr>
           <% end %>
+          <% slice_stats = job_slice_stats(@job) %>
           <tr>
-            <td><label>Queued Slices:</label></td>
-            <td><%= @job.input.queued.count %></td>
-          </tr>
-          <tr>
-            <td><label>Active Slices:</label></td>
-            <td><%= @job.input.running.count %></td>
-          </tr>
-          <tr>
-            <td><label>Failed Slices:</label></td>
-            <td><%= @job.input.failed.count %></td>
+            <td><label>Slices:</label></td>
+            <td>
+              <div class='slice-bar'>
+                <% slice_stats.each do |label, css_class, count, percent| %>
+                  <% next if percent.zero? %>
+                  <div class="slice-bar-segment <%= css_class %>" style="width: <%= percent %>%" title="<%= label %>: <%= count %>"></div>
+                <% end %>
+              </div>
+              <div class='slice-bar-legend'>
+                <% slice_stats.each do |label, css_class, count, _percent| %>
+                  <span class='slice-bar-legend-item'>
+                    <span class="slice-bar-swatch <%= css_class %>"></span><%= label %>: <%= count %>
+                  </span>
+                <% end %>
+              </div>
+            </td>
           </tr>
         <% end %>
         <tr>

--- a/rjmc/db/seeds.rb
+++ b/rjmc/db/seeds.rb
@@ -159,7 +159,7 @@ kaboom.input_category.slice_size = 10
 kaboom.upload do |stream|
   100.times { |i| stream << "Line number #{i + 1}" }
 end
-while kaboom.input.queued.count.positive?
+while kaboom.running? || kaboom.queued?
   begin
     kaboom.perform_now
   rescue StandardError
@@ -177,6 +177,40 @@ pending_batch.upload do |stream|
   25.times { |i| stream << "pat,#{30 + i},NY" }
 end
 pending_batch.save!
+
+# Partially completed running batch job, to exercise the slice progress bar on
+# the job details view. record_count is set during upload (before the job runs),
+# so the bar can show real progress. There are no workers, so simulate progress
+# by hand: 100 records at a slice_size of 10 uploads 10 slices. Rocket Job
+# deletes each input slice as it completes, so completed slices are inferred
+# from record_count. Delete six to represent completed work, mark one active and
+# one failed, and leave two queued (Completed 6, Active 1, Failed 1, Queued 2).
+partial_batch = CSVJob.new(description: "Partially processed import")
+partial_batch.input_category.slice_size = 10
+partial_batch.upload do |stream|
+  stream << "name,age,state"
+  100.times { |i| stream << "sam,#{20 + i},TX" }
+end
+pretend_running!(partial_batch, WORKERS[0])
+
+# Six completed slices: Rocket Job removes input slices once they finish.
+partial_batch.input.queued.limit(6).to_a.each(&:destroy)
+
+# One active slice, running on a worker.
+active_slice             = partial_batch.input.queued.first
+active_slice.worker_name = WORKERS[0]
+active_slice.start!
+
+# One failed slice, with an exception explaining why.
+slice_exception = begin
+  raise ArgumentError, "Invalid state code for record: 'ZZ'"
+rescue ArgumentError => e
+  e
+end
+failed_slice             = partial_batch.input.queued.first
+failed_slice.worker_name = WORKERS[1]
+failed_slice.start
+failed_slice.fail!(slice_exception)
 
 # ---------------------------------------------------------------------------
 # Servers (populates the Servers view)

--- a/test/helpers/rocket_job_mission_control/jobs_helper_test.rb
+++ b/test/helpers/rocket_job_mission_control/jobs_helper_test.rb
@@ -64,6 +64,62 @@ module RocketJobMissionControl
         end
       end
 
+      describe "#job_total_slices" do
+        it "returns nil when the record count is unknown" do
+          assert_nil job_total_slices(KaboomBatchJob.new)
+        end
+
+        it "divides the record count by the slice size, rounding up" do
+          job = KaboomBatchJob.new
+          job.input_category.slice_size = 100
+          job.record_count = 250
+          assert_equal 3, job_total_slices(job)
+        end
+      end
+
+      describe "#job_slice_stats" do
+        let :batch_job do
+          job = KaboomBatchJob.new
+          job.input_category.slice_size = 1
+          job.upload do |stream|
+            stream << "first record"
+            stream << "second record"
+            stream << "third record"
+          end
+          job.save!
+          job
+        end
+
+        after do
+          RocketJob::Job.delete_all
+        end
+
+        it "returns the four ordered buckets" do
+          labels = job_slice_stats(batch_job).map(&:first)
+          assert_equal %w[Queued Active Failed Completed], labels
+        end
+
+        it "counts every uploaded slice as queued" do
+          queued = job_slice_stats(batch_job).find { |bucket| bucket.first == "Queued" }
+          assert_equal 3, queued[2]
+          assert_in_delta 100.0, queued[3], 0.01
+        end
+
+        it "derives completed slices from the total minus those still in the queue" do
+          batch_job.input.first.start!
+          stats     = job_slice_stats(batch_job)
+          completed = stats.find { |bucket| bucket.first == "Completed" }
+          active    = stats.find { |bucket| bucket.first == "Active" }
+          assert_equal 1, active[2]
+          assert_equal 0, completed[2]
+        end
+
+        it "reports zero percentages when nothing is known" do
+          percents = job_slice_stats(KaboomBatchJob.new).map(&:last)
+          assert_equal [0, 0, 0, 0], percents
+        end
+      end
+
       describe "#job_action_link" do
         let(:action) { "abort" }
         let(:http_method) { :patch }


### PR DESCRIPTION
Closes #50.

## What

Replaces the plain Queued / Active / Failed slice counts on the batch job details view with a single horizontal stacked bar. Segments run left to right: **Queued → Active → Failed → Completed**, reusing the existing RJMC state colors (queued `#a29f00`, running `#337ab7`, failed `red`, completed `green`). A small legend under the bar keeps the exact counts.

## How completed slices are derived

Rocket Job deletes each input slice as it completes, so there is no stored "completed" count. It is derived as `total − (queued + active + failed)`, where `total = ceil(record_count / slice_size)`. The record count is set during upload, before a job starts running, so until it is known the total is nil and every segment is zero, leaving the bar empty.

## Changes

- `jobs_helper.rb` — `job_slice_stats` (four ordered `[label, css_class, count, percent]` buckets, normalized to fill the bar) and `job_total_slices`.
- `_details.html.erb` — renders the `.slice-bar` with a legend in place of the three count rows.
- `base.css.erb` — flexbox bar and legend swatches reusing the state colors.
- `rjmc/db/seeds.rb` — a "Partially processed import" running batch job (10 slices: 6 completed, 1 active, 1 failed, 2 queued) so the bar can be exercised without a running cluster.
- `jobs_helper_test.rb` — tests for `job_slice_stats` and `job_total_slices`.

The bar appears in the `running` / `paused` / `failed` batch states, same as the slice-count rows it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)