### PR TITLE
Improve failed batch record inspection and repair

### DIFF
--- a/app/assets/javascripts/rocket_job_mission_control/application.js
+++ b/app/assets/javascripts/rocket_job_mission_control/application.js
@@ -21,4 +21,5 @@
 //= require rocket_job_mission_control/selectize_init
 //= require rocket_job_mission_control/jquery.json-viewer
 //= require rocket_job_mission_control/json_tree_init
+//= require rocket_job_mission_control/backtrace
 //

--- a/app/assets/javascripts/rocket_job_mission_control/backtrace.js
+++ b/app/assets/javascripts/rocket_job_mission_control/backtrace.js
@@ -1,0 +1,17 @@
+// Toggle the job exception backtrace between its abbreviated view (application
+// frames only) and the full view (including gem and Ruby frames).
+//
+// The abbreviated view is rendered server-side by hiding rows marked
+// `.backtrace-noise` (see exception.html.erb / JobsHelper#backtrace_noise?).
+// Clicking the button adds `show-full` to the table, which reveals those rows
+// via CSS, and swaps the button label.
+(function($) {
+  $(function() {
+    $(document).on('click', '[data-backtrace-toggle]', function() {
+      var button      = $(this);
+      var table       = button.closest('.job-status').find('table.backtrace');
+      var showingFull = table.toggleClass('show-full').hasClass('show-full');
+      button.text(showingFull ? button.attr('data-label-abbreviated') : button.attr('data-label-full'));
+    });
+  });
+})(jQuery);

--- a/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
+++ b/app/assets/stylesheets/rocket_job_mission_control/base.css.erb
@@ -126,6 +126,23 @@ div.row {
   border-color: var(--cosmic-blue-dark);
 }
 
+/* Secondary buttons (Cancel and other non-primary actions): a solid light-grey
+   fill instead of Bootstrap's default white, so they read as buttons against
+   the page background. */
+.btn-default {
+  color: #333;
+  background-color: #e6e9f0;
+  border-color: #c7cede;
+}
+.btn-default:hover,
+.btn-default:focus,
+.btn-default:active,
+.btn-default.active {
+  color: #333;
+  background-color: #d4d9e6;
+  border-color: #b3bbd0;
+}
+
 /* Center the show-page action toolbar and let its groups flow inline. */
 .job-actions {
   margin-left: 0;
@@ -615,6 +632,74 @@ h3 { margin-top: 0; }
   font-size: 15px;
   font-weight: bold;
   color: var(--cosmic-blue);
+}
+
+/* Job exception backtrace: one frame per row, with a right-aligned line number.
+   Noise frames (gems / Ruby internals) are hidden until the "Full Backtrace"
+   toggle adds `show-full` to the table (see backtrace.js). */
+.section-header .backtrace-toggle {
+  float: right;
+  font-weight: normal;
+}
+.backtrace .backtrace-line-number {
+  width: 1%;
+  text-align: right;
+  color: #999;
+  white-space: nowrap;
+  padding-right: 12px;
+}
+.backtrace .backtrace-noise {
+  display: none;
+}
+.backtrace.show-full .backtrace-noise {
+  display: table-row;
+}
+
+/* Job slice records: one record per row with a right-aligned line number and a
+   per-row Edit action. The record that raised the exception is highlighted. */
+.records .records-line-number {
+  width: 1%;
+  text-align: right;
+  color: #999;
+  white-space: nowrap;
+  padding-right: 12px;
+}
+.records .records-action {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+}
+.records code {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.records .records-failed {
+  background-color: #fdecea;
+}
+.records .records-failed .records-line-number {
+  color: var(--danger, #d9534f);
+  font-weight: bold;
+}
+
+/* Slice record editor: full-width, monospace textarea sized for long records
+   (up to a few KB), with spaced action buttons below it. */
+textarea.input_slices {
+  font-family: monospace;
+  margin-bottom: 1em;
+}
+
+/* Highlight for an unprintable / invalid byte rendered as a \xHH escape in a
+   read-only record, so the byte that broke the record stands out. */
+.record-escape {
+  padding: 0 3px;
+  color: #a94442;
+  background-color: #fdecea;
+  border: 1px solid #f0c5c1;
+  border-radius: 3px;
+  font-weight: bold;
+}
+#submit .btn {
+  margin-right: 6px;
 }
 
 /* Themed collection-action buttons in the DataTables toolbar: individual,

--- a/app/controllers/rocket_job_mission_control/jobs_controller.rb
+++ b/app/controllers/rocket_job_mission_control/jobs_controller.rb
@@ -151,6 +151,8 @@ module RocketJobMissionControl
       # Instance variables to share with the view and pagination.
       @lines                 = current_failure.records
       @failure_exception     = current_failure.try!(:exception)
+      @failure_record_number = current_failure.try!(:current_record_number)
+      @first_record_number   = current_failure.try!(:first_record_number)
       @view_slice_pagination = {
         record_number: current_failure.processing_record_number,
         offset:        @offset,
@@ -166,9 +168,10 @@ module RocketJobMissionControl
       @line_index        = params[:line_index].to_i
       @offset            = params.fetch(:offset, 0).to_i
       scope              = @job.input.failed.where("exception.class_name" => error_type)
-      current_failure    = scope.order(_id: 1).limit(1).skip(@offset).first
-      @lines             = current_failure.records
-      @failure_exception = current_failure.try!(:exception)
+      current_failure      = scope.order(_id: 1).limit(1).skip(@offset).first
+      @lines               = current_failure.records
+      @failure_exception   = current_failure.try!(:exception)
+      @first_record_number = current_failure.try!(:first_record_number)
     end
 
     def update_slice
@@ -176,14 +179,17 @@ module RocketJobMissionControl
 
       # Params from the edit_slice form
       error_type      = params[:error_type]
-      offset          = params[:offset]
+      offset          = params.fetch(:offset, 0).to_i
       updated_records = params["job"]["records"]
 
-      # Finds specific slice [Array]
-      slice = @job.input.failed.skip(offset).first
+      # Find the same slice edit_slice displayed: filtered by error type and
+      # ordered so the offset selects the matching slice.
+      scope = @job.input.failed.where("exception.class_name" => error_type)
+      slice = scope.order(_id: 1).limit(1).skip(offset).first
 
-      # Converts \r\n line breaks to \n
-      updated_records.each { |record| record.gsub(/\r\n/, "\n") }
+      # Normalize CRLF on the (ASCII-safe) escaped text, then convert the
+      # \xHH / \\ escapes back into the original bytes. See RecordEscaper.
+      updated_records = updated_records.map { |record| RecordEscaper.unescape(record.gsub(/\r\n/, "\n")) }
 
       # Assings modified slice (from the form) back to slice
       slice.records = updated_records
@@ -195,6 +201,11 @@ module RocketJobMissionControl
       else
         flash[:danger] = "Error updating slice."
       end
+    rescue EncodingError => exc
+      # Mongo only stores UTF-8, so a record left with invalid bytes cannot be
+      # saved. Surface it instead of returning a 500.
+      flash[:danger] = "Error updating slice: #{exc.message}"
+      redirect_to view_slice_job_path(@job, error_type: params[:error_type])
     end
 
     def delete_line
@@ -218,8 +229,8 @@ module RocketJobMissionControl
 
       if slice.save
         logger.info("Line Deleted By #{login}, job: #{@job.id}, file_name: #{@job.upload_file_name}")
+        flash[:success] = "Record #{slice.first_record_number + line_index} removed from the slice."
         redirect_to view_slice_job_path(@job, error_type: error_type)
-        flash[:success] = "line removed"
       else
         flash[:danger] = "Error removing line."
       end
@@ -242,8 +253,9 @@ module RocketJobMissionControl
         redirect_to(job_path(@job))
       end
 
-      current_failure    = scope.order(_id: 1).limit(1).skip(offset).first
-      @failure_exception = current_failure.try!(:exception)
+      current_failure        = scope.order(_id: 1).limit(1).skip(offset).first
+      @failure_exception     = current_failure.try!(:exception)
+      @failure_record_number = current_failure.try!(:current_record_number)
 
       @pagination = {
         offset: offset,

--- a/app/helpers/rocket_job_mission_control/application_helper.rb
+++ b/app/helpers/rocket_job_mission_control/application_helper.rb
@@ -83,14 +83,6 @@ module RocketJobMissionControl
       values
     end
 
-    def escape(s)
-      s.dump[1..-2]
-    end
-
-    def unescape(s)
-      "\"#{s}\"".undump
-    end
-
     # Returns the editable field as html for use in editing dynamic fields from a Job class.
     def editable_field_html(klass, field_name, value, f)
       # When editing a job the values are of the correct type.

--- a/app/helpers/rocket_job_mission_control/jobs_helper.rb
+++ b/app/helpers/rocket_job_mission_control/jobs_helper.rb
@@ -168,5 +168,66 @@ module RocketJobMissionControl
       categories.each { |category| return category if category_name == (category["name"] || :main).to_sym }
       nil
     end
+
+    # Paths that live inside a gem or Ruby's standard library. Frames rooted at
+    # any of these are treated as noise and hidden from the abbreviated
+    # backtrace. This mirrors SemanticLogger::Utils.strip_path? without depending
+    # on that internal method, so it keeps working regardless of the installed
+    # Semantic Logger version.
+    def backtrace_strip_paths
+      @backtrace_strip_paths ||= (Gem.path | [Gem.default_dir, RbConfig::CONFIG["rubylibdir"]]).compact
+    end
+
+    # Returns [true|false] whether the backtrace line originates from a gem or
+    # from Ruby itself, and so should be omitted from the abbreviated backtrace.
+    def backtrace_noise?(line)
+      backtrace_strip_paths.any? { |path| line.to_s.start_with?(path) }
+    end
+
+    # Reversible, ASCII-safe form of a failed record for an edit textarea.
+    # See RecordEscaper; unescape it with RecordEscaper.unescape on save.
+    def escape_record(value)
+      RecordEscaper.escape(value)
+    end
+
+    # Read-only HTML for a failed record, with each unprintable/invalid byte
+    # rendered as a highlighted `\xHH` token. Each highlight carries a hover
+    # tooltip naming the byte, so an operator can see (in context) exactly which
+    # byte broke the record and what it is.
+    def highlight_record(value)
+      safe_join(
+        RecordEscaper.segments(value).map do |type, text|
+          next text if type == :text
+
+          content_tag(:span, text, class: "record-escape", title: record_escape_title(text))
+        end
+      )
+    end
+
+    # Human-readable names for the control bytes that can appear as escapes, used
+    # for the hover tooltip on a highlighted record byte. Tab/LF/CR are shown as
+    # real whitespace, so they never reach here.
+    CONTROL_NAMES = {
+      0x00 => "NUL", 0x01 => "SOH", 0x02 => "STX", 0x03 => "ETX", 0x04 => "EOT",
+      0x05 => "ENQ", 0x06 => "ACK", 0x07 => "BEL", 0x08 => "BS",  0x0B => "VT",
+      0x0C => "FF",  0x0E => "SO",  0x0F => "SI",  0x10 => "DLE", 0x11 => "DC1",
+      0x12 => "DC2", 0x13 => "DC3", 0x14 => "DC4", 0x15 => "NAK", 0x16 => "SYN",
+      0x17 => "ETB", 0x18 => "CAN", 0x19 => "EM",  0x1A => "SUB", 0x1B => "ESC",
+      0x1C => "FS",  0x1D => "GS",  0x1E => "RS",  0x1F => "US",  0x7F => "DEL"
+    }.freeze
+
+    # Tooltip text explaining why a highlighted token is shown as an escape.
+    def record_escape_title(token)
+      if token == "\\\\"
+        "Literal backslash, escaped as \\\\"
+      elsif (match = token.match(/\A\\x(\h{2})\z/))
+        byte = match[1].to_i(16)
+        name = CONTROL_NAMES[byte]
+        base = "Unprintable byte 0x#{match[1]}"
+        name ? "#{base} (#{name})" : base
+      else
+        "Escaped byte"
+      end
+    end
   end
 end

--- a/app/models/rocket_job_mission_control/record_escaper.rb
+++ b/app/models/rocket_job_mission_control/record_escaper.rb
@@ -1,0 +1,91 @@
+module RocketJobMissionControl
+  # Makes the unprintable content of a failed batch record safe to display and
+  # (losslessly) edit in the browser.
+  #
+  # A record that caused a job to fail often contains control characters (NUL,
+  # ESC, backspace, ...) or, rarely, invalid UTF-8 bytes. Rendered raw these are
+  # invisible in HTML and silently stripped or normalized by a textarea, so an
+  # operator cannot see why the record failed and editing corrupts it.
+  #
+  # This escapes each such byte to a reversible `\xHH` token (and `\` to `\\`),
+  # while leaving ordinary printable text, including valid multibyte Unicode, and
+  # tab / newline / carriage-return untouched so normal records stay readable.
+  # `unescape` reverses `escape` exactly, byte for byte.
+  module RecordEscaper
+    module_function
+
+    # Control bytes left as-is: tab, line feed, carriage return. They are visible
+    # whitespace a textarea handles naturally, so escaping them would only hurt
+    # readability.
+    KEEP_CONTROL = [0x09, 0x0A, 0x0D].freeze
+
+    ESCAPE_TOKEN = /\A\\(?:\\|x\h{2})/.freeze
+
+    # Returns the record split into an ordered list of [type, string] pairs where
+    # type is :text for readable content and :escape for a `\xHH` / `\\` token.
+    # Views build either plain text (edit) or highlighted HTML (display) from it.
+    def segments(value)
+      segments = []
+      buffer   = +""
+      flush    = lambda do
+        segments << [:text, buffer.dup] unless buffer.empty?
+        buffer.clear
+      end
+
+      value.to_s.each_char do |char|
+        if !char.valid_encoding?
+          flush.call
+          char.bytes.each { |byte| segments << [:escape, format("\\x%02X", byte)] }
+        elsif char == "\\"
+          flush.call
+          segments << [:escape, "\\\\"]
+        elsif control?(char)
+          flush.call
+          segments << [:escape, format("\\x%02X", char.ord)]
+        else
+          buffer << char
+        end
+      end
+
+      flush.call
+      segments
+    end
+
+    # Reversible, ASCII-safe representation of the record for an edit textarea.
+    def escape(value)
+      segments(value).map { |_type, text| text }.join
+    end
+
+    # Reverses escape: turns `\xHH` back into its byte and `\\` back into `\`.
+    # Any other backslash sequence is left verbatim (it was never produced by
+    # escape, so it can only come from the user typing it). Returns UTF-8 when
+    # the result is valid, otherwise the raw bytes so nothing is lost.
+    def unescape(escaped)
+      bytes = +"".b
+      chars = escaped.to_s.chars
+      index = 0
+
+      while index < chars.length
+        char = chars[index]
+        if char == "\\" && chars[index + 1] == "\\"
+          bytes << 0x5C
+          index += 2
+        elsif char == "\\" && chars[index + 1] == "x" && "#{chars[index + 2]}#{chars[index + 3]}".match?(/\A\h{2}\z/)
+          bytes << "#{chars[index + 2]}#{chars[index + 3]}".to_i(16)
+          index += 4
+        else
+          bytes << char.b
+          index += 1
+        end
+      end
+
+      utf8 = bytes.dup.force_encoding("UTF-8")
+      utf8.valid_encoding? ? utf8 : bytes
+    end
+
+    def control?(char)
+      char.bytesize == 1 && ((ord = char.ord) < 0x20 || ord == 0x7F) && !KEEP_CONTROL.include?(ord)
+    end
+    private_class_method :control?
+  end
+end

--- a/app/views/rocket_job_mission_control/jobs/_exception_details.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/_exception_details.html.erb
@@ -1,0 +1,19 @@
+<div class='section-header'>Exception</div>
+<div class='row'>
+  <div class='col-md-12'>
+    <table>
+      <tr>
+        <td><label>Class Name:</label></td>
+        <td><%= exception.class_name %></td>
+      </tr>
+      <tr>
+        <td><label>Message:</label></td>
+        <td><%= exception.message %></td>
+      </tr>
+      <tr>
+        <td><label>Record:</label></td>
+        <td><%= record_number %></td>
+      </tr>
+    </table>
+  </div>
+</div>

--- a/app/views/rocket_job_mission_control/jobs/edit_slice.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/edit_slice.html.erb
@@ -1,24 +1,36 @@
-<div class='edit_input'>
-  <div class='col-md-10'>
-    <% valid_events = @job.aasm.events.collect { |e| e.name } %>
-    <br>
-    <br>
-    <%= form_for(:job, url: update_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name), method: :patch) do |f| %>
-      <% @lines.each_with_index do |line, index| %>
-        <% if @line_index == index %>
-          <%= f.text_area :records, value: line, class: 'input_slices', id: index, multiple: true, rows: 14, cols: 10, wrap: "soft" %>
-        <% else %>
-          <%= f.hidden_field :records, value: line, class: 'input_slices', id: index, multiple: true %>
+<div class='row'>
+  <div class='col-md-12'>
+    <div class="panel panel-default">
+      <div class="panel-heading page-title-bar">
+        <h2 class='page-title'>
+          <%= link_to(@job.class.name, job_path(@job)) %> Edit Slice
+        </h2>
+      </div>
+    </div>
+
+    <div class='job-status'>
+      <div class='section-header'>Edit Record: <%= @first_record_number + @line_index %></div>
+
+      <p class='help-block'>
+        Unprintable bytes are shown as <code>\xHH</code> escapes (for example a null byte as <code>\x00</code>)
+        and are converted back to the original bytes when saved. A literal backslash is shown as <code>\\</code>.
+      </p>
+
+      <%= form_for(:job, url: update_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name), method: :patch) do |f| %>
+        <% @lines.each_with_index do |line, index| %>
+          <% if @line_index == index %>
+            <%= f.text_area :records, value: escape_record(line), class: 'input_slices form-control', id: index, multiple: true, rows: 20, wrap: "soft" %>
+          <% else %>
+            <%= f.hidden_field :records, value: escape_record(line), class: 'input_slices', id: index, multiple: true %>
+          <% end %>
         <% end %>
+
+        <div id='submit'>
+          <%= f.submit 'Save', class: 'btn btn-primary' %>
+          <%= link_to 'Delete', delete_line_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: @line_index), :data => {:confirm => "Record #{@first_record_number + @line_index} will be deleted from the slice. Are you sure?"}, method: :patch, class: 'btn btn-danger' %>
+          <%= link_to 'Cancel', view_slice_job_path(@job, error_type: @failure_exception.class_name, record_number: @job.input.failed.first.processing_record_number), class: 'btn btn-default' %>
+        </div>
       <% end %>
-
-      <div id='submit'>
-        <%= f.submit 'Save', class: 'btn btn-primary' %>
-        <%= link_to 'Delete', delete_line_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: @line_index), :data => {:confirm => 'Are you sure?'}, method: :patch, class: 'btn btn-danger' %>
-        <%= link_to 'Cancel', view_slice_job_path(@job, error_type: @failure_exception.class_name, record_number: @job.input.failed.first.processing_record_number), class: 'btn btn-default' %>
-    <% end %>
-
     </div>
   </div>
 </div>
-

--- a/app/views/rocket_job_mission_control/jobs/exception.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/exception.html.erb
@@ -1,10 +1,12 @@
 <div class='row'>
-  <div class='col-md-8'>
+  <div class='col-md-12'>
     <div class="panel panel-default">
       <div class="panel-heading page-title-bar">
         <div class='row'>
           <div class='col-sm-8'>
-            <h2 class='page-title'><%= link_to(@job.class.name, job_path(@job)) %>: <%= @failure_exception.class_name %></h2>
+            <h2 class='page-title'>
+              <%= link_to(@job.class.name, job_path(@job)) %> Exception
+            </h2>
           </div>
 
           <div class='col-sm-4'>
@@ -17,15 +19,43 @@
     </div>
 
     <div class='job-status'>
-      <div class='failures'>
-        <div class='message'>
-          <pre><code class="language-html"><%= @failure_exception.message %></code></pre>
+      <%= render partial: 'exception_details', locals: {exception: @failure_exception, record_number: @failure_record_number} %>
+
+      <% if @failure_exception.backtrace.present? %>
+        <% backtrace = @failure_exception.backtrace %>
+        <% noise     = backtrace.map { |line| backtrace_noise?(line) } %>
+        <%# Only abbreviate when at least one application frame remains, otherwise %>
+        <%# the abbreviated backtrace would be empty. %>
+        <% abbreviate = noise.include?(false) %>
+
+        <div class='section-header'>
+          Backtrace
+          <% if abbreviate && noise.include?(true) %>
+            <button type='button'
+                    class='btn btn-primary btn-sm backtrace-toggle'
+                    data-backtrace-toggle
+                    data-label-full='Full Backtrace'
+                    data-label-abbreviated='Abbreviated Backtrace'>
+              Full Backtrace
+            </button>
+          <% end %>
         </div>
 
-        <div class='error'>
-          <pre class='small'><%= @failure_exception.backtrace.join("\n") %></pre>
+        <div class='row'>
+          <div class='col-md-12'>
+            <table class='table backtrace'>
+              <tbody>
+                <% backtrace.each_with_index do |line, index| %>
+                  <tr class='<%= "backtrace-noise" if abbreviate && noise[index] %>'>
+                    <td class='backtrace-line-number'><%= index + 1 %></td>
+                    <td><code><%= line %></code></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/view_slice.html.erb
@@ -1,10 +1,12 @@
-<div class='edit_input'>
-  <div class='col-md-10'>
+<div class='row'>
+  <div class='col-md-12'>
     <div class="panel panel-default">
       <div class="panel-heading page-title-bar">
         <div class='row'>
           <div class='col-sm-8'>
-            <h2 class='page-title'><%= link_to(@job.class, job_path(@job)) %>: <%= @failure_exception.class_name %></h2>
+            <h2 class='page-title'>
+              <%= link_to(@job.class.name, job_path(@job)) %> Exception
+            </h2>
           </div>
 
           <div class='col-sm-4'>
@@ -17,36 +19,38 @@
     </div>
 
     <div class='job-status'>
-      <div class='failures'>
-        <div class='message'>
-          <pre><code class="language-html"><%= @failure_exception.message %></code></pre>
-        </div>
+      <%= render partial: 'exception_details', locals: {exception: @failure_exception, record_number: @failure_record_number} %>
 
+      <div class='section-header'>Records</div>
+
+      <div class='row'>
+        <div class='col-md-12'>
+          <table class='table records'>
+            <thead>
+              <tr>
+                <th class='records-line-number'>Record</th>
+                <th>Content</th>
+                <% if can?(:edit_slice, @job) %><th class='records-action'></th><% end %>
+              </tr>
+            </thead>
+            <tbody>
+              <% @lines.each_with_index do |line, index| %>
+                <% failed = (index + 1 == @view_slice_pagination[:record_number]) %>
+                <tr id="<%= index + 1 %>" tabindex="<%= index + 1 %>" class='<%= "records-failed" if failed %>'>
+                  <td class='records-line-number'><%= @first_record_number + index %></td>
+                  <td><code><%= highlight_record(line) %></code></td>
+                  <% if can?(:edit_slice, @job) %>
+                    <td class='records-action'>
+                      <%= link_to "Edit", edit_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: index), class: 'btn btn-primary btn-sm' %>
+                    </td>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
-
-    <% @lines.each_with_index do |line, index| %>
-      <% if index + 1 == @view_slice_pagination[:record_number] %>
-        <% if flash[:success] %>
-          <%= render partial: 'layouts/rocket_job_mission_control/partials/flash' %>
-          <br>
-        <% end %>
-
-        <div class='message' tabindex="<%= index + 1 %>" id="<%= index + 1 %>">
-
-        <pre><span>Line: <%= index + 1 %></span><br><br><code><%= line %></code><br><br>
-          <% if can?(:edit_slice, @job) %><div class='edit_button'><%= link_to "Edit", edit_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: index), class: 'btn btn-primary' %></div><% end %><div class='edit_button'> <%= link_to "Back", job_path(@job), class: 'btn btn-warning' %></div>
-        </pre>
-        </div>
-      <% else %>
-        <div class='message' tabindex="<%= index + 1 %>" id="<%= index + 1 %>">
-        <pre><span>Line: <%= index + 1 %></span><br><br><code><%= line %></code><br><br>
-          <% if can?(:edit_slice, @job) %><div class='edit_button'><%= link_to "Edit", edit_slice_job_path(@job, offset: @offset, error_type: @failure_exception.class_name, line_index: index), class: 'btn btn-primary' %></div><% end %>
-        </pre>
-        </div>
-      <% end %>
-    <% end %>
-
   </div>
 </div>
 

--- a/rjmc/app/jobs/kaboom_batch_job.rb
+++ b/rjmc/app/jobs/kaboom_batch_job.rb
@@ -13,10 +13,6 @@ class KaboomBatchJob < RocketJob::Job
   self.destroy_on_complete = false
 
   def perform(_record)
-    if rocket_job_record_number.even?
-      raise "Blowing up on record: #{rocket_job_record_number}"
-    else
-      raise ArgumentError, "Blowing up on record: #{rocket_job_record_number}"
-    end
+    raise ArgumentError, "Blowing up on record: #{rocket_job_record_number}"
   end
 end

--- a/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
@@ -39,7 +39,7 @@ module RocketJobMissionControl
         3.times do
           begin
             job.perform_now
-          rescue ArgumentError, RuntimeError
+          rescue ArgumentError, RuntimeError, EOFError
           end
         end
         job
@@ -209,8 +209,13 @@ module RocketJobMissionControl
           end
 
           describe "with exception" do
+            # Derive the error type from a real failed slice so the test does not
+            # depend on which error class KaboomBatchJob raised for each slice.
+            let(:failed_slice) { failed_job.input.failed.order(_id: 1).first }
+            let(:error_type)   { failed_slice.exception.class_name }
+
             before do
-              get :exception, params: {id: failed_job.id, error_type: "ArgumentError"}
+              get :exception, params: {id: failed_job.id, error_type: error_type}
             end
 
             it "succeeds" do
@@ -222,13 +227,14 @@ module RocketJobMissionControl
             end
 
             it "paginates" do
-              assert_equal 0, assigns(:pagination)[:offset], assigns(:pagination)
-              assert_equal 1, assigns(:pagination)[:total], assigns(:pagination)
+              expected_total = failed_job.input.failed.where("exception.class_name" => error_type).count - 1
+              assert_equal 0,              assigns(:pagination)[:offset], assigns(:pagination)
+              assert_equal expected_total, assigns(:pagination)[:total],  assigns(:pagination)
             end
 
             it "returns the first exception" do
-              assert_equal "ArgumentError", assigns(:failure_exception).class_name
-              assert_equal "Blowing up on record: 1", assigns(:failure_exception).message
+              assert_equal error_type,                    assigns(:failure_exception).class_name
+              assert_equal failed_slice.exception.message, assigns(:failure_exception).message
               assert assigns(:failure_exception).backtrace.present?
             end
           end
@@ -409,28 +415,143 @@ module RocketJobMissionControl
         end
       end
 
-      %i[view_slice edit_slice].each do |method|
-        describe "with a failed slice" do
-          it "access ##{method}" do
-            params = {:error_type => "ArgumentError", "record_number" => "9", "id" => failed_job.id}
-            get method, params: params
-            assert_response :success
+      # Derive the error type and slice from a real failed slice so the lookups
+      # (which filter by error type) match the slice under test, regardless of
+      # which error class KaboomBatchJob happened to raise for each slice.
+      describe "#view_slice" do
+        let(:failed_slice) { failed_job.input.failed.order(_id: 1).first }
+        let(:error_type)   { failed_slice.exception.class_name }
+
+        before do
+          get :view_slice, params: {id: failed_job.id, error_type: error_type, offset: "0"}
+        end
+
+        it "succeeds" do
+          assert_response :success
+        end
+
+        it "assigns the failed slice details" do
+          assert_equal error_type,                          assigns(:failure_exception).class_name
+          assert_equal failed_slice.current_record_number,  assigns(:failure_record_number)
+          assert_equal failed_slice.first_record_number,    assigns(:first_record_number)
+          assert_equal failed_slice.records,                assigns(:lines)
+        end
+
+        it "paginates from the requested offset" do
+          assert_equal 0,                                  assigns(:view_slice_pagination)[:offset]
+          assert_equal failed_slice.processing_record_number, assigns(:view_slice_pagination)[:record_number]
+        end
+
+        it "renders the exception title and section" do
+          assert_includes response.body, failed_job.class.name
+          assert_includes response.body, "Exception"
+          assert_includes response.body, error_type
+          assert_includes response.body, failed_slice.exception.message
+        end
+
+        it "renders the records section with each record and its number" do
+          assert_includes response.body, "Records"
+          assert_includes response.body, "Content"
+          failed_slice.records.each_with_index do |record, index|
+            assert_includes response.body, record
+            assert_includes response.body, (failed_slice.first_record_number + index).to_s
           end
+        end
+
+        it "highlights the failed record" do
+          assert_includes response.body, "records-failed"
+        end
+
+        it "highlights unprintable bytes in a record" do
+          failed_slice.records = ["null\x00byte"]
+          failed_slice.save!
+          get :view_slice, params: {id: failed_job.id, error_type: error_type, offset: "0"}
+          assert_includes response.body, "record-escape"
+          assert_includes response.body, "\\x00"
+        end
+      end
+
+      describe "#edit_slice" do
+        let(:failed_slice) { failed_job.input.failed.order(_id: 1).first }
+        let(:error_type)   { failed_slice.exception.class_name }
+
+        before do
+          get :edit_slice, params: {id: failed_job.id, error_type: error_type, offset: "0", line_index: "0"}
+        end
+
+        it "succeeds" do
+          assert_response :success
+        end
+
+        it "assigns the slice details" do
+          assert_equal error_type,                       assigns(:failure_exception).class_name
+          assert_equal failed_slice.first_record_number, assigns(:first_record_number)
+          assert_equal failed_slice.records,             assigns(:lines)
+          assert_equal 0,                                assigns(:line_index)
+        end
+
+        it "renders the edit slice title and record header" do
+          assert_includes response.body, "Edit Slice"
+          assert_includes response.body, "Edit Record: #{failed_slice.first_record_number}"
+        end
+
+        it "renders an editable text area for the record" do
+          assert_match(/<textarea[^>]*input_slices/, response.body)
+        end
+
+        it "shows unprintable bytes as escapes in the text area" do
+          failed_slice.records = ["null\x00byte"]
+          failed_slice.save!
+          get :edit_slice, params: {id: failed_job.id, error_type: error_type, offset: "0", line_index: "0"}
+          assert_includes response.body, "null\\x00byte"
+        end
+
+        it "confirms deletion with the record number" do
+          assert_includes response.body, "Record #{failed_slice.first_record_number} will be deleted from the slice."
         end
       end
 
       describe "#update slice" do
+        # Derive the error type from an actual failed slice so the lookup (which
+        # filters by error type) matches the slice that was edited.
+        let(:error_type) { failed_job.input.failed.order(_id: 1).first.exception.class_name }
+
         before do
-          params = {"job" => {"records" => %w[1 2 3]}, "error_type" => "CSV::MalformedCSVError", "offset" => "1", "id" => failed_job.id.to_s}
+          params = {"job" => {"records" => %w[1 2 3]}, "error_type" => error_type, "offset" => "0", "id" => failed_job.id.to_s}
           post :update_slice, params: params
         end
 
         it "redirects" do
-          assert_redirected_to view_slice_job_path(failed_job, error_type: "CSV::MalformedCSVError")
+          assert_redirected_to view_slice_job_path(failed_job, error_type: error_type)
         end
 
         it "adds a flash success message" do
           assert_equal "slice updated", flash[:success]
+        end
+
+        it "unescapes submitted records back to their original bytes" do
+          slice = failed_job.input.failed.order(_id: 1).first
+          post :update_slice, params: {
+            "job"        => {"records" => ["null\\x00byte"]},
+            "error_type" => slice.exception.class_name,
+            "offset"     => "0",
+            "id"         => failed_job.id.to_s
+          }
+          slice.reload
+          assert_equal "null\x00byte", slice.records.first
+        end
+
+        it "reports an error instead of raising when a record cannot be stored" do
+          slice = failed_job.input.failed.order(_id: 1).first
+          # \xA3 unescapes to an invalid UTF-8 byte, which Mongo cannot store.
+          post :update_slice, params: {
+            "job"        => {"records" => ["bad\\xA3byte"]},
+            "error_type" => slice.exception.class_name,
+            "offset"     => "0",
+            "id"         => failed_job.id.to_s
+          }
+          assert_response :redirect
+          assert flash[:danger].present?
         end
       end
     end

--- a/test/models/rocket_job_mission_control/record_escaper_test.rb
+++ b/test/models/rocket_job_mission_control/record_escaper_test.rb
@@ -1,0 +1,71 @@
+require_relative "../../test_helper"
+
+class RecordEscaperTest < Minitest::Test
+  describe RocketJobMissionControl::RecordEscaper do
+    Escaper = RocketJobMissionControl::RecordEscaper
+
+    describe ".escape" do
+      it "leaves ordinary printable text untouched" do
+        assert_equal "plain text 123", Escaper.escape("plain text 123")
+      end
+
+      it "leaves valid multibyte Unicode readable" do
+        assert_equal "日本語 café", Escaper.escape("日本語 café")
+      end
+
+      it "keeps tab, newline and carriage return as-is" do
+        assert_equal "a\tb\nc\rd", Escaper.escape("a\tb\nc\rd")
+      end
+
+      it "escapes control characters as \\xHH" do
+        assert_equal "a\\x00b\\x1Bc\\x7F", Escaper.escape("a\x00b\x1Bc\x7F")
+      end
+
+      it "escapes a literal backslash" do
+        assert_equal "a\\\\b", Escaper.escape("a\\b")
+      end
+
+      it "escapes invalid UTF-8 bytes" do
+        assert_equal "x\\xA3y", Escaper.escape("x\xA3y".dup.force_encoding("UTF-8"))
+      end
+    end
+
+    describe ".unescape" do
+      it "reverses control character escapes to the original bytes" do
+        assert_equal "a\x00b\x1Bc", Escaper.unescape("a\\x00b\\x1Bc")
+      end
+
+      it "reverses an escaped backslash" do
+        assert_equal "a\\b", Escaper.unescape("a\\\\b")
+      end
+
+      it "leaves an unrecognized backslash sequence verbatim" do
+        assert_equal "a\\z", Escaper.unescape("a\\z")
+      end
+    end
+
+    describe "round trip" do
+      [
+        "plain text",
+        "日本語 é ok",
+        "control\x00\x1B\x07\bbytes",
+        "tab\tnewline\nend",
+        "back\\slash",
+        "del\x7Fbyte",
+        "invalid\xA3utf8".dup.force_encoding("UTF-8")
+      ].each do |original|
+        it "restores every byte of #{original.inspect}" do
+          restored = Escaper.unescape(Escaper.escape(original))
+          assert_equal original.b, restored.b
+        end
+      end
+    end
+
+    describe ".segments" do
+      it "splits text and escape tokens in order" do
+        assert_equal [[:text, "a"], [:escape, "\\x00"], [:text, "b"]],
+                     Escaper.segments("a\x00b")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reworks the exception, view slice, and edit slice pages so an operator can understand and fix the record that caused a batch job to fail, and handles records containing control characters or other unprintable bytes.

## Exception page
- Retitled to `<JobClass> Exception`; shows class name, message, and the failing record number in the standard label/value table layout.
- Backtrace is rendered as a table, **abbreviated to application frames by default** with a "Full Backtrace" toggle. Gem/Ruby frames are detected without depending on a Semantic Logger internal method (works across Semantic Logger versions).

## View / edit slice pages
- Share the exception details through a new `_exception_details` partial; both pages get consistent titles and full-width layout.
- Slice contents render in a professional **Records** table that numbers each record (`first_record_number + offset`) and **highlights the failed record**.
- Edit slice gains an "Edit Record: N" sub-title and a delete confirmation that names the record being removed.

## Unprintable / non-UTF-8 bytes
- New `RecordEscaper` renders control characters and invalid bytes as reversible `\xHH` escapes while leaving printable text and valid Unicode (日本語, é) readable.
- **View slice** highlights each escaped byte with a hover tooltip naming it (e.g. "Unprintable byte 0x00 (NUL)").
- **Edit slice** shows the escaped form and unescapes on save, giving a lossless round trip (the browser otherwise silently strips/normalizes control chars).
- `update_slice` is guarded so a record that cannot be stored (Mongo is UTF-8 only) reports an error instead of returning a 500.

## Fixes
- `update_slice` looked the slice up **without** the error-type filter or ordering used by `edit_slice`, so **Save could persist to the wrong slice**. It now selects the same slice and normalizes line endings correctly.
- Removed the unused `escape`/`unescape` helpers, superseded by `RecordEscaper`.

## Tests
- `RecordEscaper` unit tests: escape/unescape and byte-exact round trips for NUL/ESC/BS/DEL/backslash/invalid-UTF-8, plus segment splitting.
- Controller tests for the exception, view slice, and edit slice pages, including unprintable-byte highlighting, the escape/unescape round trip through save, and the unstorable-byte guard.
- Made the previously flaky `#exception` pagination/message assertions deterministic (derive the error type and expected counts from a real failed slice).

## Notes
- RuboCop is intentionally **not** addressed here; it will be handled in a separate PR.
- Includes a small dummy-app tweak (`KaboomBatchJob` always raises `ArgumentError`) so the failure path is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)