### PR TITLE
Add "Show Workers" button to batch job view (#49)

### DIFF
--- a/app/datatables/rocket_job_mission_control/active_workers_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/active_workers_datatable.rb
@@ -11,9 +11,10 @@ module RocketJobMissionControl
     def map(active_worker)
       {
         "0"           => worker_name_with_icon(active_worker, active_worker.job),
-        "1"           => job_name_with_link(active_worker.job.class.name, active_worker.job.id),
-        "2"           => h(active_worker.job.description.try!(:truncate, 50)),
-        "3"           => h("#{active_worker.duration} ago"),
+        "1"           => server_status(active_worker),
+        "2"           => job_name_with_link(active_worker.job.class.name, active_worker.job.id),
+        "3"           => h(active_worker.job.description.try!(:truncate, 50)),
+        "4"           => h("#{active_worker.duration} ago"),
         "DT_RowClass" => "card callout callout-running"
       }
     end
@@ -23,6 +24,22 @@ module RocketJobMissionControl
       <<-EOS
         <i class="#{state_icon(state)}" style="font-size: 75%" title="#{state}"></i>
         #{active_worker.name}
+      EOS
+    end
+
+    # The server the worker is running on, along with its current status.
+    # A missing server means the worker has been orphaned (zombie).
+    def server_status(active_worker)
+      if active_worker.zombie?
+        state = :zombie
+        label = "zombie"
+      else
+        state = active_worker.server.state
+        label = h(state)
+      end
+      <<-EOS
+        <i class="#{state_icon(state)}" style="font-size: 75%" title="#{state}"></i>
+        #{h(active_worker.server_name)} (#{label})
       EOS
     end
 

--- a/app/views/rocket_job_mission_control/active_workers/index.html.erb
+++ b/app/views/rocket_job_mission_control/active_workers/index.html.erb
@@ -24,10 +24,11 @@
           <h4> For Job: <%= link_to(@job.class.name, job_path(@job)) %> ID:<%= link_to(@job.id, job_path(@job)) %></h4>
         <% end %>
 
-        <table class='table datatable active-workers-datatable' data-source='<%= active_workers_url(format: 'json') %>' style='width: 100%'>
+        <table class='table datatable active-workers-datatable' data-source='<%= active_workers_url(format: 'json', job_id: @job&.id, server_name: @server_name) %>' style='width: 100%'>
           <thead>
             <tr>
               <th>Worker Name</th>
+              <th>Server</th>
               <th>Class</th>
               <th>Description</th>
               <th>Started</th>
@@ -45,7 +46,7 @@
   jQuery(function() {
     new RjmcDatatable(
       $('.active-workers-datatable'),
-      [{data: '0'}, {data: '1'}, {data: '2'}, {data: '3'}],
+      [{data: '0'}, {data: '1'}, {data: '2'}, {data: '3'}, {data: '4'}],
       { ordering: false, searching: false });
   });
 </script>

--- a/app/views/rocket_job_mission_control/jobs/show.html.erb
+++ b/app/views/rocket_job_mission_control/jobs/show.html.erb
@@ -12,6 +12,12 @@
       </div>
     <% end %>
 
+    <% if @job.respond_to?(:input_category) && @job.running? && can?(:read, RocketJob::Worker) %>
+      <div class='btn-group'>
+        <%= link_to 'Show Workers', active_workers_path(job_id: @job.id), class: 'btn btn-default' %>
+      </div>
+    <% end %>
+
     <div class='left-margin'>
       <% valid_events = @job.aasm.events.collect { |e| e.name } %>
       <% if valid_events.include?(:pause) && @job.pausable? && can?(:pause, @job) %>

--- a/rjmc/db/seeds.rb
+++ b/rjmc/db/seeds.rb
@@ -256,6 +256,10 @@ failed_slice.worker_name = WORKERS[1]
 failed_slice.start
 failed_slice.fail!(slice_exception)
 
+# Mark the job as processing slices so the active slice above is reported as an
+# active worker, driving the "Show Workers" button on the batch job view.
+partial_batch.update!(sub_state: :processing)
+
 # ---------------------------------------------------------------------------
 # Servers (populates the Servers view)
 # ---------------------------------------------------------------------------

--- a/test/controllers/rocket_job_mission_control/active_workers_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/active_workers_controller_test.rb
@@ -1,0 +1,70 @@
+require_relative "../../test_helper"
+
+module RocketJobMissionControl
+  class ActiveWorkersControllerTest < ActionController::TestCase
+    describe ActiveWorkersController do
+      before do
+        set_role(:admin)
+        RocketJob::Job.delete_all
+        RocketJob::Server.delete_all
+      end
+
+      let :running_job do
+        RocketJob::Jobs::SimpleJob.create!(state: :running, worker_name: "server1:1234:worker1", started_at: Time.now - 5)
+      end
+
+      let :other_running_job do
+        RocketJob::Jobs::SimpleJob.create!(state: :running, worker_name: "server2:5678:worker1", started_at: Time.now - 5)
+      end
+
+      describe "GET #index" do
+        describe "without a job_id" do
+          before do
+            running_job
+            other_running_job
+          end
+
+          it "renders successfully" do
+            get :index
+            assert_response :success
+            assert_nil assigns(:job)
+          end
+
+          it "returns the active workers for every running job" do
+            get :index, format: :json
+            assert_response :success
+            data = JSON.parse(response.body)["data"]
+            assert_equal 2, data.size
+          end
+        end
+
+        describe "with a job_id" do
+          before do
+            running_job
+            other_running_job
+          end
+
+          it "assigns the requested job" do
+            get :index, params: {job_id: running_job.id}
+            assert_response :success
+            assert_equal running_job.id, assigns(:job).id
+          end
+
+          it "returns only the active workers for the requested job" do
+            get :index, params: {job_id: running_job.id}, format: :json
+            assert_response :success
+            data = JSON.parse(response.body)["data"]
+            assert_equal 1, data.size
+            assert_includes data.first["0"], running_job.worker_name
+          end
+        end
+      end
+    end
+
+    def set_role(r)
+      Config.authorization_callback = lambda {
+        {roles: [r]}
+      }
+    end
+  end
+end


### PR DESCRIPTION
Closes #49.

When viewing a running Batch Job, display a **Show Workers** button that links to the Active Workers page filtered to that job, with server status shown next to each worker.

## Changes

- **Show Workers button** ([jobs/show.html.erb](app/views/rocket_job_mission_control/jobs/show.html.erb)) — added to the job actions toolbar, gated on batch job (`respond_to?(:input_category)`) + `running?` + `can?(:read, RocketJob::Worker)`. Links to `active_workers_path(job_id: @job.id)`.
- **Fixed a filtering bug** ([active_workers/index.html.erb](app/views/rocket_job_mission_control/active_workers/index.html.erb)) — the DataTables `data-source` now passes `job_id` and `server_name` through to the JSON request. Previously the follow-up JSON request dropped them and returned all workers regardless of the requested filter.
- **New Server column** ([active_workers_datatable.rb](app/datatables/rocket_job_mission_control/active_workers_datatable.rb)) — shows the server name and its status with an icon: the server's live state (running/paused/…) for healthy workers, or `zombie` when the server no longer exists. Reuses the already-memoized `active_worker.server`, so no extra DB queries.
- **Tests** — new `ActiveWorkersControllerTest` covering the unfiltered path (all workers) and the `job_id`-filtered path (assigns `@job`, returns only that job's workers).
- **Seed data** ([rjmc/db/seeds.rb](rjmc/db/seeds.rb)) — set the partially-processed batch job to `sub_state: :processing` so its active slice surfaces as a per-slice active worker, giving the button real data. Seeded servers already match the worker prefixes, so the Server column renders real (non-zombie) states.

## Verification

- New `active_workers_controller_test.rb`: 4 runs, 0 failures.
- Full `jobs_controller_test.rb`: 148 runs, 0 failures.
- `bin/rake db:seed` runs cleanly (88 jobs, 6 servers).

## Note

The button is scoped to batch jobs per the issue title. The underlying `rocket_job_active_workers` works for any running job, so extending it to non-batch running jobs would be a one-line condition change if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)