### PR TITLE
Make the access policy class configurable

### DIFF
--- a/app/controllers/rocket_job_mission_control/application_controller.rb
+++ b/app/controllers/rocket_job_mission_control/application_controller.rb
@@ -20,8 +20,13 @@ module RocketJobMissionControl
           else
             {roles: %i[admin]}
           end
-        RocketJobMissionControl::AccessPolicy.new(Authorization.new(**@args))
+        access_policy_class.new(Authorization.new(**@args))
       end
+    end
+
+    def access_policy_class
+      policy = Config.access_policy_class || RocketJobMissionControl::AccessPolicy
+      policy.is_a?(Class) ? policy : policy.to_s.constantize
     end
 
     def login

--- a/lib/rocket_job_mission_control/engine.rb
+++ b/lib/rocket_job_mission_control/engine.rb
@@ -2,6 +2,11 @@ module RocketJobMissionControl
   # The authorization callback
   module Config
     mattr_accessor :authorization_callback
+
+    # The access policy class used to authorize actions.
+    # Defaults to RocketJobMissionControl::AccessPolicy when not set.
+    # May be a class, or a String/Symbol naming the class.
+    mattr_accessor :access_policy_class
   end
 
   class Engine < ::Rails::Engine

--- a/test/controllers/rocket_job_mission_control/application_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/application_controller_test.rb
@@ -9,10 +9,44 @@ module RocketJobMissionControl
     end
   end
 
+  class CustomAccessPolicy < AccessPolicy
+  end
+
   class ApplicationControllerTest < ActionController::TestCase
     tests TestController
 
     describe TestController do
+      describe "#access_policy_class" do
+        before do
+          @original_policy_class = Config.access_policy_class
+          @original_callback     = Config.authorization_callback
+          Config.authorization_callback = nil
+        end
+
+        after do
+          Config.access_policy_class    = @original_policy_class
+          Config.authorization_callback = @original_callback
+        end
+
+        it "defaults to AccessPolicy when not configured" do
+          Config.access_policy_class = nil
+          assert_equal AccessPolicy, @controller.send(:access_policy_class)
+          assert_instance_of AccessPolicy, @controller.send(:current_policy)
+        end
+
+        it "uses a configured policy class" do
+          Config.access_policy_class = CustomAccessPolicy
+          assert_equal CustomAccessPolicy, @controller.send(:access_policy_class)
+          assert_instance_of CustomAccessPolicy, @controller.send(:current_policy)
+        end
+
+        it "constantizes a policy class supplied as a String" do
+          Config.access_policy_class = "RocketJobMissionControl::CustomAccessPolicy"
+          assert_equal CustomAccessPolicy, @controller.send(:access_policy_class)
+          assert_instance_of CustomAccessPolicy, @controller.send(:current_policy)
+        end
+      end
+
       describe "#with_time_zone" do
         before do
           @routes = ActionDispatch::Routing::RouteSet.new


### PR DESCRIPTION
## Summary

Adds a `config.rocket_job_mission_control.access_policy_class` option so a host app can supply its own [access-granted](https://github.com/chaps-io/access-granted) policy instead of the built-in `RocketJobMissionControl::AccessPolicy`.

Previously the policy class was hardcoded in `ApplicationController#current_policy`; the only lever for authorization was the `authorization_callback` (which controls *which roles* a user gets, not *what the roles can do*). This makes the permission rules themselves overridable.

## Changes

- `Config` gains a `access_policy_class` accessor (`lib/rocket_job_mission_control/engine.rb`).
- `ApplicationController#current_policy` resolves the class via a new `access_policy_class` helper. It accepts either a `Class` or a `String`/`Symbol` naming it (constantized lazily, so it can be set from an initializer without autoloading the class too early), and falls back to `RocketJobMissionControl::AccessPolicy` when unset.
- Tests covering the default, a configured class, and a String-named class.

Default behavior is unchanged when the option is not set.

## Usage

~~~ruby
class MyAccessPolicy < RocketJobMissionControl::AccessPolicy
  def configure
    super
    role :auditor do
      can :read, RocketJob::Job
    end
  end
end

RocketJobMissionControl::Engine.config.rocket_job_mission_control.access_policy_class = MyAccessPolicy
~~~

## Test plan

- [x] `appraisal rails_8.1 ruby -Itest test/controllers/rocket_job_mission_control/application_controller_test.rb` — 6 runs, 9 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)