### PR TITLE
Add test coverage tooling and raise coverage to 96%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bundle/
 *.log
 pkg/
+coverage/
 rjmc/tmp/
 rjmc4/tmp/
 *.gem

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "sprockets"
 
 gem "minispec-rails", require: false
 gem "rails-controller-testing"
+gem "simplecov", require: false
+
+gem "solargraph", require: false
 
 gem "bundler-audit", require: false
 gem "rubocop", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 gem "minitest", "~> 5.0"
-gem "mongoid", "~> 9.0.0"
-gem "rails", "~> 7.2.0"
+gem "mongoid", "~> 9.1.0"
+gem "rails", "~> 8.1.0"
 gem "rocketjob", github: "reidmorrison/rocketjob"
 gem "sprockets-rails"
 

--- a/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
+++ b/app/controllers/rocket_job_mission_control/dirmon_entries_controller.rb
@@ -139,11 +139,6 @@ module RocketJobMissionControl
       end
     end
 
-    def properties
-      @dirmon_entry = RocketJob::DirmonEntry.new(dirmon_params)
-      render json: @dirmon_entry
-    end
-
     private
 
     def authorize_read

--- a/app/datatables/rocket_job_mission_control/active_workers_datatable.rb
+++ b/app/datatables/rocket_job_mission_control/active_workers_datatable.rb
@@ -50,9 +50,5 @@ module RocketJobMissionControl
         </a>
       EOS
     end
-
-    def duration(started_at)
-      "#{RocketJob.seconds_as_duration(Time.now - started_at)} ago" if started_at
-    end
   end
 end

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -13,6 +13,9 @@ gem "rubyzip", platform: :ruby
 gem "sprockets"
 gem "minispec-rails", require: false
 gem "rails-controller-testing"
+gem "simplecov", require: false
+gem "solargraph", require: false
+gem "bundler-audit", require: false
 gem "rubocop", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -13,6 +13,9 @@ gem "rubyzip", platform: :ruby
 gem "sprockets"
 gem "minispec-rails", require: false
 gem "rails-controller-testing"
+gem "simplecov", require: false
+gem "solargraph", require: false
+gem "bundler-audit", require: false
 gem "rubocop", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -13,6 +13,9 @@ gem "rubyzip", platform: :ruby
 gem "sprockets"
 gem "minispec-rails", require: false
 gem "rails-controller-testing"
+gem "simplecov", require: false
+gem "solargraph", require: false
+gem "bundler-audit", require: false
 gem "rubocop", require: false
 gem "rubocop-minitest", require: false
 gem "rubocop-performance", require: false

--- a/test/controllers/rocket_job_mission_control/dirmon_entries_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/dirmon_entries_controller_test.rb
@@ -312,6 +312,64 @@ module RocketJobMissionControl
         end
       end
 
+      describe "GET #copy" do
+        before do
+          get :copy, params: {id: existing_dirmon_entry.id}
+        end
+
+        it "succeeds" do
+          assert_response :success
+        end
+
+        it "assigns the entry" do
+          assert_equal existing_dirmon_entry, assigns(:dirmon_entry)
+        end
+      end
+
+      describe "PATCH #replicate" do
+        describe "with valid parameters" do
+          before do
+            patch :replicate, params: {
+              id:                      existing_dirmon_entry.id,
+              rocket_job_dirmon_entry: {
+                name:           "Replicated entry",
+                pattern:        "replicated_path",
+                job_class_name: job_class_name,
+                properties:     {}
+              }
+            }
+          end
+
+          it "redirects to the new entry" do
+            new_entry = RocketJob::DirmonEntry.where(name: "Replicated entry").first
+            assert_redirected_to dirmon_entry_path(new_entry)
+          end
+
+          it "creates a copy without destroying the original" do
+            assert RocketJob::DirmonEntry.where(name: "Replicated entry").exists?
+            assert RocketJob::DirmonEntry.where(id: existing_dirmon_entry.id).exists?
+          end
+        end
+
+        describe "with invalid parameters" do
+          before do
+            patch :replicate, params: {
+              id:                      existing_dirmon_entry.id,
+              rocket_job_dirmon_entry: {name: "Broken", job_class_name: "FakeAndBadJob"}
+            }
+          end
+
+          it "re-renders the copy form" do
+            assert_response :success
+            assert_template :copy
+          end
+
+          it "carries the validation errors on the entry" do
+            assert assigns(:dirmon_entry).errors.present?
+          end
+        end
+      end
+
       ([:index] + dirmon_entry_states).each do |state|
         describe "GET ##{state}" do
           describe "html" do

--- a/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/jobs_controller_test.rb
@@ -551,6 +551,92 @@ module RocketJobMissionControl
           assert flash[:danger].present?
         end
       end
+
+      describe "GET #edit" do
+        describe "with a valid job id" do
+          before do
+            get :edit, params: {id: job.id}
+          end
+
+          it "succeeds" do
+            assert_response :success
+          end
+
+          it "assigns the job" do
+            assert_equal job.id, assigns(:job).id
+          end
+        end
+
+        describe "with an invalid job id" do
+          before do
+            get :edit, params: {id: 42}
+          end
+
+          it "redirects" do
+            assert_redirected_to jobs_path
+          end
+        end
+      end
+
+      describe "DELETE #destroy" do
+        describe "with a valid job id" do
+          before do
+            job
+            delete :destroy, params: {id: job.id}
+          end
+
+          it "redirects to the jobs list" do
+            assert_redirected_to jobs_path
+          end
+
+          it "removes the job" do
+            assert_nil RocketJob::Job.where(id: job.id).first
+          end
+        end
+
+        describe "with an invalid job id" do
+          before do
+            delete :destroy, params: {id: 42}
+          end
+
+          it "redirects" do
+            assert_redirected_to jobs_path
+          end
+        end
+      end
+
+      describe "PATCH #update with an invalid value" do
+        before do
+          # priority must be within 1..100, so this fails validation and the
+          # controller re-renders the edit form instead of redirecting.
+          patch :update, params: {id: job.id, job: {id: job.id, priority: 500}}
+        end
+
+        it "re-renders the edit form" do
+          assert_response :success
+          assert_template :edit
+        end
+
+        it "does not persist the invalid value" do
+          assert_equal 50, job.reload.priority
+        end
+      end
+
+      describe "PATCH #delete_line" do
+        let(:error_type) { failed_job.input.failed.order(_id: 1).first.exception.class_name }
+
+        before do
+          patch :delete_line, params: {id: failed_job.id, error_type: error_type, offset: "0", line_index: "0"}
+        end
+
+        it "redirects to the slice view" do
+          assert_redirected_to view_slice_job_path(failed_job, error_type: error_type)
+        end
+
+        it "adds a flash success message" do
+          assert_match(/removed from the slice/, flash[:success])
+        end
+      end
     end
 
     def set_role(r)

--- a/test/controllers/rocket_job_mission_control/servers_controller_test.rb
+++ b/test/controllers/rocket_job_mission_control/servers_controller_test.rb
@@ -77,6 +77,36 @@ module RocketJobMissionControl
             end
           end
         end
+
+        describe "with 'destroy_zombies' as the server_action param" do
+          before do
+            patch :update_all, params: {server_action: :destroy_zombies}
+          end
+
+          it "redirects to servers" do
+            assert_redirected_to servers_path
+          end
+
+          it "does not display an error message" do
+            assert_nil flash[:danger]
+          end
+        end
+
+        describe "with an authorized but unsupported server_action param" do
+          before do
+            # :destroy is permitted for an admin but is not one of VALID_ACTIONS,
+            # so it falls through to the invalid branch.
+            patch :update_all, params: {server_action: :destroy}
+          end
+
+          it "redirects to servers" do
+            assert_redirected_to servers_path
+          end
+
+          it "displays an invalid action error message" do
+            assert_equal I18n.t(:invalid, scope: %i[server update_all]), flash[:danger]
+          end
+        end
       end
 
       describe "DELETE #destroy" do

--- a/test/datatables/rocket_job_mission_control/abstract_datatable_test.rb
+++ b/test/datatables/rocket_job_mission_control/abstract_datatable_test.rb
@@ -1,0 +1,77 @@
+require_relative "../../test_helper"
+
+module RocketJobMissionControl
+  class AbstractDatatableTest < ActiveSupport::TestCase
+    # Minimal stand-in for the view: AbstractDatatable only delegates #params to it.
+    class FakeView
+      attr_reader :params
+
+      def initialize(params)
+        @params = ActionController::Parameters.new(params)
+      end
+    end
+
+    def build_query
+      query                 = RocketJobMissionControl::Query.new(RocketJob::Job.all, _id: 1)
+      query.display_columns = %w[name state]
+      query
+    end
+
+    def build(params)
+      AbstractDatatable.new(FakeView.new(params), build_query)
+    end
+
+    describe AbstractDatatable do
+      describe "#map" do
+        it "must be implemented by subclasses" do
+          datatable = build({})
+          assert_raises(NotImplementedError) { datatable.send(:map, Object.new) }
+        end
+      end
+
+      describe "pagination params" do
+        it "applies start and page size from the request" do
+          datatable = build(start: "5", length: "25")
+          assert_equal 5, datatable.query.start
+          assert_equal 25, datatable.query.page_size
+        end
+
+        it "defaults the page size to 10" do
+          datatable = build(start: "0")
+          assert_equal 10, datatable.query.page_size
+        end
+
+        it "skips pagination when length is -1 (show all)" do
+          datatable = build(length: "-1")
+          assert_nil datatable.query.start
+          assert_nil datatable.query.page_size
+        end
+      end
+
+      describe "search params" do
+        it "assigns the search term when present" do
+          datatable = build(search: {value: "widgets"})
+          assert_equal "widgets", datatable.query.search_term
+        end
+
+        it "leaves the search term unset when blank" do
+          datatable = build(search: {value: ""})
+          assert_nil datatable.query.search_term
+        end
+      end
+
+      describe "sort params" do
+        it "maps a column index and direction onto the query order" do
+          datatable = build(order: {"0" => {column: "1", dir: "asc"}})
+          assert_equal({"state" => "asc"}, datatable.query.order_by)
+        end
+
+        it "raises for a column index outside the display columns" do
+          assert_raises(ArgumentError) do
+            build(order: {"0" => {column: "9", dir: "asc"}})
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/rocket_job_mission_control/application_helper_test.rb
+++ b/test/helpers/rocket_job_mission_control/application_helper_test.rb
@@ -48,6 +48,66 @@ module RocketJobMissionControl
           end
         end
       end
+
+      describe "#state?" do
+        it "is true for a known state" do
+          assert state?("completed")
+        end
+
+        it "is case insensitive" do
+          assert state?("Running")
+        end
+
+        it "is false for an unknown state" do
+          assert_not state?("bogus")
+        end
+      end
+
+      describe "#render_json_tree" do
+        it "wraps the value in a json-tree container" do
+          html = render_json_tree({"a" => 1})
+          assert_match(/class="json-tree"/, html)
+          assert_match(%r{<script type="application/json">}, html)
+        end
+
+        it "renders a noscript plain-text fallback" do
+          html = render_json_tree([1, 2, 3])
+          assert_match(/<noscript>/, html)
+          assert_match(/<pre>/, html)
+        end
+
+        it "does not collapse small collections" do
+          html = render_json_tree((1..5).to_a)
+          assert_match(/data-collapsed="false"/, html)
+        end
+
+        it "collapses collections past the threshold" do
+          html = render_json_tree((1..20).to_a)
+          assert_match(/data-collapsed="true"/, html)
+        end
+      end
+
+      describe "#extract_inclusion_values" do
+        it "returns the inclusion list for a validated attribute" do
+          klass = Class.new do
+            include ActiveModel::Validations
+            attr_accessor :color
+
+            validates :color, inclusion: {in: %w[red green blue]}
+          end
+          assert_equal %w[red green blue], extract_inclusion_values(klass, :color)
+        end
+
+        it "returns nil when the attribute has no inclusion validator" do
+          klass = Class.new do
+            include ActiveModel::Validations
+            attr_accessor :name
+
+            validates :name, presence: true
+          end
+          assert_nil extract_inclusion_values(klass, :name)
+        end
+      end
     end
   end
 end

--- a/test/helpers/rocket_job_mission_control/dirmon_entries_helper_test.rb
+++ b/test/helpers/rocket_job_mission_control/dirmon_entries_helper_test.rb
@@ -1,0 +1,46 @@
+require_relative "../../test_helper"
+
+module RocketJobMissionControl
+  class DirmonEntriesHelperTest < ActionView::TestCase
+    describe DirmonEntriesHelper do
+      describe "#dirmon_counts_by_state" do
+        it "returns the count for a state, defaulting to zero" do
+          RocketJob::DirmonEntry.delete_all
+          RocketJob::DirmonEntry.create!(name: "test", pattern: "/tmp/*", job_class_name: "AllTypesJob")
+          assert_equal 1, dirmon_counts_by_state(:pending)
+          assert_equal 0, dirmon_counts_by_state(:failed)
+        end
+      end
+
+      describe "#dirmon_entry_find_category" do
+        let(:categories) { [{"name" => "main"}, {"name" => "errors"}] }
+
+        it "returns nil when categories is nil" do
+          assert_nil dirmon_entry_find_category(nil)
+        end
+
+        it "defaults to the main category" do
+          assert_equal({"name" => "main"}, dirmon_entry_find_category(categories))
+        end
+
+        it "finds a named category" do
+          assert_equal({"name" => "errors"}, dirmon_entry_find_category(categories, :errors))
+        end
+
+        it "treats a nameless category as main" do
+          assert_equal({}, dirmon_entry_find_category([{}], :main))
+        end
+
+        it "returns nil when no category matches" do
+          assert_nil dirmon_entry_find_category(categories, :missing)
+        end
+      end
+
+      describe "#rocket_job_mission_control" do
+        it "exposes the engine url helpers" do
+          assert_respond_to rocket_job_mission_control, :jobs_path
+        end
+      end
+    end
+  end
+end

--- a/test/helpers/rocket_job_mission_control/jobs_helper_test.rb
+++ b/test/helpers/rocket_job_mission_control/jobs_helper_test.rb
@@ -142,6 +142,120 @@ module RocketJobMissionControl
           assert_match(/data-method="patch"/, action_link)
         end
       end
+
+      describe "#job_state_name" do
+        it "camelcases the @job state" do
+          @job = RocketJob::Jobs::SimpleJob.new
+          assert_equal "Queued", job_state_name(@job)
+        end
+
+        it "reflects the scheduled special case" do
+          @job = RocketJob::Jobs::SimpleJob.new(run_at: 1.day.from_now)
+          assert_equal "Scheduled", job_state_name(@job)
+        end
+      end
+
+      describe "#job_state_time" do
+        it "returns the run_at time when scheduled" do
+          run_at = 1.day.from_now
+          job    = RocketJob::Jobs::SimpleJob.new(run_at: run_at)
+          assert_equal run_at.in_time_zone(Time.zone), job_state_time(job)
+        end
+
+        it "falls back to created_at for a queued job" do
+          job = RocketJob::Jobs::SimpleJob.new
+          assert_equal job.created_at.in_time_zone(Time.zone), job_state_time(job)
+        end
+      end
+
+      describe "#job_estimated_time_left" do
+        it "returns nil when the job is not running" do
+          job = KaboomBatchJob.new(record_count: 100)
+          assert_nil job_estimated_time_left(job)
+        end
+
+        it "returns nil when less than five percent complete" do
+          job = KaboomBatchJob.new(record_count: 100)
+          job.stub(:running?, true) do
+            job.stub(:percent_complete, 1) do
+              assert_nil job_estimated_time_left(job)
+            end
+          end
+        end
+
+        it "estimates the remaining duration once enough progress is made" do
+          job = KaboomBatchJob.new(record_count: 100)
+          job.stub(:running?, true) do
+            job.stub(:percent_complete, 50) do
+              job.stub(:seconds, 10.0) do
+                assert_equal RocketJob.seconds_as_duration(10.0), job_estimated_time_left(job)
+              end
+            end
+          end
+        end
+      end
+
+      describe "#job_records_per_hour" do
+        it "returns nil when the job is not completed" do
+          job = KaboomBatchJob.new(record_count: 100)
+          assert_nil job_records_per_hour(job)
+        end
+
+        it "returns records per hour for a completed job" do
+          job = KaboomBatchJob.new(record_count: 100)
+          job.stub(:completed?, true) do
+            job.stub(:seconds, 60.0) do
+              assert_equal 6000, job_records_per_hour(job)
+            end
+          end
+        end
+      end
+
+      describe "#job_selected_class" do
+        let(:job) { RocketJob::Jobs::SimpleJob.new }
+
+        it "returns 'selected' when the job is the selected job" do
+          assert_equal "selected", job_selected_class(job, job)
+        end
+
+        it "returns an empty string when no job is selected" do
+          assert_equal "", job_selected_class(job, nil)
+        end
+
+        it "returns an empty string for a different job" do
+          assert_equal "", job_selected_class(job, RocketJob::Jobs::SimpleJob.new)
+        end
+      end
+
+      describe "#job_find_category" do
+        let(:categories) { [{"name" => "main"}, {"name" => "errors"}] }
+
+        it "returns nil when categories is nil" do
+          assert_nil job_find_category(nil)
+        end
+
+        it "finds the matching category by name" do
+          assert_equal({"name" => "errors"}, job_find_category(categories, :errors))
+        end
+
+        it "returns nil when no category matches" do
+          assert_nil job_find_category(categories, :missing)
+        end
+      end
+
+      describe "#record_escape_title" do
+        it "describes a literal escaped backslash" do
+          assert_equal "Literal backslash, escaped as \\\\", record_escape_title("\\\\")
+        end
+
+        it "names a known control byte" do
+          assert_equal "Unprintable byte 0x00 (NUL)", record_escape_title("\\x00")
+        end
+
+        it "falls back for an unrecognized token" do
+          assert_equal "Escaped byte", record_escape_title("nope")
+        end
+      end
     end
   end
 end

--- a/test/models/rocket_job_mission_control/query_test.rb
+++ b/test/models/rocket_job_mission_control/query_test.rb
@@ -66,6 +66,14 @@ class QueryTest < Minitest::Test
         assert_equal 2, count
       end
 
+      it "searches directly when there is a single search column" do
+        q                = RocketJobMissionControl::Query.new(NoopJob.all, description: 1)
+        q.search_columns = [:description]
+        q.search_term    = "Job 1"
+
+        assert_equal 2, q.query.to_a.size
+      end
+
       it "paginates with sort" do
         q           = RocketJobMissionControl::Query.new(NoopJob.all, _id: 1)
         q.start     = 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,11 @@
 ENV["RAILS_ENV"] ||= "test"
 
+require "simplecov"
+SimpleCov.start "rails" do
+  add_filter "/test/"
+  add_filter "/rjmc/"
+end
+
 require "yaml"
 require "rails/version"
 require_relative "../rjmc/config/environment"


### PR DESCRIPTION
## Summary

Adds SimpleCov + Solargraph, then raises line coverage from **89.11% → 96.15%** by testing previously-uncovered helpers, controllers, datatables, and the query model. Also removes two pieces of confirmed dead code and bumps the root Gemfile to Rails 8.1 / Mongoid 9.1.

## Changes

**Tooling**
- SimpleCov (`require: false`), started at the top of `test_helper.rb` before the Rails app loads, using the `rails` profile with `/test/` and `/rjmc/` filtered out. `coverage/` is gitignored.
- Solargraph (`require: false`) for editor LSP.
- Regenerated appraisal gemfiles via `appraisal install`.

**New / expanded tests**
- Helpers: `jobs_helper` (state/time/estimate/records-per-hour/find-category/escape-title), `application_helper` (`state?`, `render_json_tree`, `extract_inclusion_values`), new `dirmon_entries_helper` test file.
- Controllers: jobs (`#edit`, `#destroy`, invalid `#update` re-render, `#delete_line`), dirmon (`#copy`, `#replicate` success + invalid), servers (`update_all` `destroy_zombies` and invalid-action branches).
- Query: single-search-column branch.
- New `abstract_datatable` test: `map` NotImplementedError, pagination (start/length/-1), search term, and sort-column mapping incl. out-of-range ArgumentError.

**Dead code removed**
- `ActiveWorkersDatatable#duration` — never called; the table uses the model's `active_worker.duration`.
- `DirmonEntriesController#properties` — no route; the form's `#properties` button navigates to `new_dirmon_entry_path`.

**Gemfile**
- Root Gemfile bumped to Rails 8.1 / Mongoid 9.1.

## Coverage

| | Before | After |
|---|---|---|
| Line coverage | 89.11% | 96.15% |
| Covered lines | 884 | 949 |
| Test runs | 440 | 503 |

Remaining uncovered lines are the practical floor: `editable_field_html`/`link_to_add_fields` form-builder branches, the datatable `map` HTML builders (need live job/server/worker fixtures), and the by-design-unreachable production `rescue_from`/`error_occurred` branches (`raise ... if Rails.env.test?`).

## Test plan
- [x] `appraisal rails_8.1 rake test` — 503 runs, 902 assertions, 0 failures, 0 errors
- [x] `rubocop` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)